### PR TITLE
feat: add shared configs, sync --check, and new templates

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -7,16 +7,20 @@ OzzyLabs リポジトリ共通の開発設定。
 ## 構成
 
 ```text
-shared/          -> 全リポジトリに同期（毎回上書き）
+shared/              -> 全リポジトリに同期（毎回上書き）
   .claude/
-    skills/      -> 共通ワークフロースキル
-    rules/       -> 共通ルール
-templates/       -> 初期セットアップ用（存在しない場合のみコピー）
+    skills/          -> 共通ワークフロースキル
+    rules/           -> 共通ルール
+  lefthook-base.yaml -> 共通 lefthook ベース設定
+  .commitlintrc.yaml -> 共通 commitlint 設定
+templates/           -> 初期セットアップ用（存在しない場合のみコピー）
   CLAUDE.md
+  SECURITY.md
   .claude/
     settings.json
     skills/lint-rules/
-sync.sh          -> 同期スクリプト
+  .mcp.json
+sync.sh              -> 同期スクリプト
 ```
 
 ## 使い方
@@ -30,6 +34,9 @@ sync.sh          -> 同期スクリプト
 
 # コピーせず差分のみ表示
 /path/to/dev-config/sync.sh --dry-run /path/to/target-repo
+
+# 共有ファイルの同期状態をチェック（CI 用）
+/path/to/dev-config/sync.sh --check /path/to/target-repo
 ```
 
 共有ファイルは毎回上書きされる。テンプレートは対象ファイルが存在しない場合のみコピーされる。同期後、対象リポジトリの `.claude/.dev-config-sync` にソースのコミットハッシュとタイムスタンプが記録される。
@@ -40,6 +47,8 @@ sync.sh          -> 同期スクリプト
 |------|----------|------|
 | スキル | commit, commit-conventions, drive, implement, lint, pr, review, ship, test | ワークフロー制御 |
 | ルール | git-workflow.md | ブランチ・コミット・PR 規約 |
+| 設定 | lefthook-base.yaml | 共通 lefthook ベース（commit-msg + 共通リンター） |
+| 設定 | .commitlintrc.yaml | Conventional Commits 検証 |
 
 ## テンプレート
 
@@ -48,6 +57,8 @@ sync.sh          -> 同期スクリプト
 | `CLAUDE.md` | プロジェクト概要、コマンド、検証手順 |
 | `.claude/settings.json` | 許可ツール・権限設定 |
 | `.claude/skills/lint-rules/` | リンターコマンド対応表（リポジトリ固有） |
+| `SECURITY.md` | 脆弱性報告ポリシー |
+| `.mcp.json` | MCP サーバー設定（Context7） |
 
 ## リポジトリ固有のまま残すもの
 

--- a/README.md
+++ b/README.md
@@ -7,16 +7,20 @@ Shared configurations for OzzyLabs repositories.
 ## Structure
 
 ```text
-shared/          -> Synced to every repo (always overwrite)
+shared/              -> Synced to every repo (always overwrite)
   .claude/
-    skills/      -> Shared workflow skills
-    rules/       -> Shared rules
-templates/       -> Copied on initial setup only (if not exists)
+    skills/          -> Shared workflow skills
+    rules/           -> Shared rules
+  lefthook-base.yaml -> Shared lefthook base config
+  .commitlintrc.yaml -> Shared commitlint config
+templates/           -> Copied on initial setup only (if not exists)
   CLAUDE.md
+  SECURITY.md
   .claude/
     settings.json
     skills/lint-rules/
-sync.sh          -> Sync script
+  .mcp.json
+sync.sh              -> Sync script
 ```
 
 ## Usage
@@ -30,6 +34,9 @@ sync.sh          -> Sync script
 
 # Preview changes without copying
 /path/to/dev-config/sync.sh --dry-run /path/to/target-repo
+
+# Check if shared files are in sync (for CI)
+/path/to/dev-config/sync.sh --check /path/to/target-repo
 ```
 
 Shared files are always overwritten. Templates are copied only if the target file does not exist. After sync, a metadata file (`.claude/.dev-config-sync`) is written to the target with the source commit hash and timestamp.
@@ -40,6 +47,8 @@ Shared files are always overwritten. Templates are copied only if the target fil
 |------|-------|---------|
 | Skills | commit, commit-conventions, drive, implement, lint, pr, review, ship, test | Workflow orchestration |
 | Rules | git-workflow.md | Branch, commit, PR conventions |
+| Config | lefthook-base.yaml | Shared lefthook base (commit-msg + common linters) |
+| Config | .commitlintrc.yaml | Conventional Commits validation |
 
 ## What is templated
 
@@ -48,6 +57,8 @@ Shared files are always overwritten. Templates are copied only if the target fil
 | `CLAUDE.md` | Project overview, commands, verification steps |
 | `.claude/settings.json` | Allowed tools and permissions |
 | `.claude/skills/lint-rules/` | Linter command mapping (repo-specific) |
+| `SECURITY.md` | Security vulnerability reporting policy |
+| `.mcp.json` | MCP server configuration (Context7) |
 
 ## What stays in each repo
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -48,6 +48,13 @@ templates/.claude/settings.json        → <repo>/.claude/settings.json
 |--------|------|
 | git-workflow.md | ブランチ・コミット・PR 規約、禁止事項 |
 
+### 共通設定ファイル（`shared/`）
+
+| ファイル | 役割 |
+|----------|------|
+| lefthook-base.yaml | lefthook の共通ベース設定（commit-msg + 共通リンター）。各リポの lefthook.yaml から `extends` で参照 |
+| .commitlintrc.yaml | Conventional Commits の検証設定 |
+
 ## テンプレート一覧
 
 | ファイル | コピー先 | 役割 |
@@ -55,6 +62,8 @@ templates/.claude/settings.json        → <repo>/.claude/settings.json
 | `CLAUDE.md` | リポジトリルート | プロジェクト概要、コマンド、検証手順の雛形 |
 | `.claude/settings.json` | `.claude/` | 許可コマンドの雛形 |
 | `.claude/skills/lint-rules/SKILL.md` | `.claude/skills/lint-rules/` | リンターコマンド対応表の雛形 |
+| `SECURITY.md` | リポジトリルート | 脆弱性報告ポリシー（Private Vulnerability Reporting 誘導） |
+| `.mcp.json` | リポジトリルート | MCP サーバー設定の雛形（Context7） |
 
 ## 共有 vs テンプレートの判断基準
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "lefthook install || true",
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules'",
-    "lint:yaml": "yamlfmt -lint .commitlintrc.yaml .yamlfmt.yaml .yamllint.yaml lefthook.yaml && yamllint -c .yamllint.yaml .",
+    "lint:yaml": "yamlfmt -lint .commitlintrc.yaml .yamlfmt.yaml .yamllint.yaml lefthook.yaml shared/lefthook-base.yaml shared/.commitlintrc.yaml && yamllint -c .yamllint.yaml .",
     "lint:shell": "find . -name '*.sh' -not -path './node_modules/*' -exec shellcheck {} + && find . -name '*.sh' -not -path './node_modules/*' -exec shfmt -d {} +",
     "lint:secrets": "gitleaks detect --no-banner",
     "lint:all": "pnpm run lint:md && pnpm run lint:yaml && pnpm run lint:shell && pnpm run lint:secrets",

--- a/shared/.commitlintrc.yaml
+++ b/shared/.commitlintrc.yaml
@@ -1,0 +1,2 @@
+extends:
+  - "@commitlint/config-conventional"

--- a/shared/lefthook-base.yaml
+++ b/shared/lefthook-base.yaml
@@ -1,0 +1,35 @@
+# Shared base config from dev-config
+# Extend this in your repo's lefthook.yaml:
+#
+#   extends:
+#     - lefthook-base.yaml
+#
+# Then add repo-specific commands (biome, taplo, ruff, etc.)
+
+commit-msg:
+  commands:
+    commitlint:
+      run: npx commitlint --edit {1}
+
+pre-commit:
+  parallel: true
+  commands:
+    shellcheck:
+      glob: "*.sh"
+      run: shellcheck {staged_files}
+    shfmt:
+      glob: "*.sh"
+      run: shfmt -w {staged_files}
+      stage_fixed: true
+    markdownlint:
+      glob: "*.md"
+      run: markdownlint-cli2 {staged_files}
+    yamlfmt:
+      glob: "*.{yaml,yml}"
+      run: yamlfmt {staged_files}
+      stage_fixed: true
+    yamllint:
+      glob: "*.{yaml,yml}"
+      run: yamllint -c .yamllint.yaml {staged_files}
+    gitleaks:
+      run: gitleaks protect --staged --no-banner

--- a/sync.sh
+++ b/sync.sh
@@ -7,6 +7,7 @@ set -euo pipefail
 # Options:
 #   --force     Sync without confirmation
 #   --dry-run   Show what would be synced without copying
+#   --check     Exit 1 if shared files are out of sync (for CI)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SHARED_DIR="${SCRIPT_DIR}/shared"
@@ -15,6 +16,7 @@ TEMPLATES_DIR="${SCRIPT_DIR}/templates"
 # Parse arguments
 FORCE=false
 DRY_RUN=false
+CHECK=false
 while [[ "${1:-}" == --* ]]; do
   case "$1" in
   --force)
@@ -23,6 +25,10 @@ while [[ "${1:-}" == --* ]]; do
     ;;
   --dry-run)
     DRY_RUN=true
+    shift
+    ;;
+  --check)
+    CHECK=true
     shift
     ;;
   *)
@@ -38,6 +44,7 @@ if [[ $# -lt 1 ]]; then
   echo "  Options:" >&2
   echo "    --force     Sync without confirmation" >&2
   echo "    --dry-run   Show what would be synced without copying" >&2
+  echo "    --check     Exit 1 if shared files are out of sync (for CI)" >&2
   exit 1
 fi
 
@@ -108,6 +115,17 @@ done
 
 # Count actionable items
 total_copy=$((${#shared_new[@]} + ${#shared_changed[@]} + ${#template_new[@]}))
+
+# Check mode: exit 1 if shared files are out of sync
+if [[ "${CHECK}" == true ]]; then
+  out_of_sync=$((${#shared_new[@]} + ${#shared_changed[@]}))
+  if [[ ${out_of_sync} -gt 0 ]]; then
+    echo "Shared files are out of sync."
+    exit 1
+  fi
+  echo "Shared files are up to date."
+  exit 0
+fi
 
 if [[ ${total_copy} -eq 0 ]]; then
   echo ""

--- a/templates/.mcp.json
+++ b/templates/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it through [GitHub Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+1. Go to the **Security** tab of this repository
+2. Click **Report a vulnerability**
+3. Fill in the details and submit
+
+We will acknowledge your report within 3 business days and aim to release a fix as soon as possible.
+
+**Please do not open a public issue for security vulnerabilities.**

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -10,8 +10,12 @@ setup() {
   mkdir -p "${SRC_DIR}/templates/.claude/skills/lint-rules"
   echo "shared skill" > "${SRC_DIR}/shared/.claude/skills/commit/SKILL.md"
   echo "shared rule" > "${SRC_DIR}/shared/.claude/rules/git-workflow.md"
+  echo "shared lefthook" > "${SRC_DIR}/shared/lefthook-base.yaml"
+  echo "shared commitlint" > "${SRC_DIR}/shared/.commitlintrc.yaml"
   echo "template lint" > "${SRC_DIR}/templates/.claude/skills/lint-rules/SKILL.md"
   echo "template claude" > "${SRC_DIR}/templates/CLAUDE.md"
+  echo "template security" > "${SRC_DIR}/templates/SECURITY.md"
+  echo "template mcp" > "${SRC_DIR}/templates/.mcp.json"
 
   # Init as git repo (needed for metadata commit hash)
   git -C "${SRC_DIR}" init -q
@@ -108,6 +112,40 @@ teardown() {
   run "${SRC_DIR}/sync.sh" --force "${TARGET_DIR}"
   [ "$status" -eq 0 ]
   [[ "$output" == *"Nothing to sync."* ]]
+}
+
+@test "--check exits 0 when shared files are up to date" {
+  "${SRC_DIR}/sync.sh" --force "${TARGET_DIR}"
+
+  run "${SRC_DIR}/sync.sh" --check "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"up to date"* ]]
+}
+
+@test "--check exits 1 when shared files are out of sync" {
+  run "${SRC_DIR}/sync.sh" --check "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"out of sync"* ]]
+}
+
+@test "--check exits 1 when shared files have changed" {
+  "${SRC_DIR}/sync.sh" --force "${TARGET_DIR}"
+
+  # Modify source
+  echo "updated skill" > "${SRC_DIR}/shared/.claude/skills/commit/SKILL.md"
+
+  run "${SRC_DIR}/sync.sh" --check "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"out of sync"* ]]
+}
+
+@test "--check does not copy files" {
+  run "${SRC_DIR}/sync.sh" --check "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  # Files should NOT exist in target
+  [ ! -f "${TARGET_DIR}/.claude/skills/commit/SKILL.md" ]
+  # Metadata should NOT exist
+  [ ! -f "${TARGET_DIR}/.claude/.dev-config-sync" ]
 }
 
 @test "errors when target is not a git repository" {


### PR DESCRIPTION
## Summary

- `shared/lefthook-base.yaml`: lefthook の共通ベース設定を追加（commit-msg + 共通リンター 6 種）。各リポの `lefthook.yaml` から `extends` で参照する運用
- `shared/.commitlintrc.yaml`: Conventional Commits 検証設定を共有化
- `sync.sh --check`: shared ファイルの同期漏れを CI で検出するモードを追加（差分あれば exit 1）
- `templates/SECURITY.md`: 脆弱性報告ポリシー（Private Vulnerability Reporting 誘導、英語）
- `templates/.mcp.json`: MCP サーバー設定テンプレート（Context7）
- テスト 4 件追加（--check の正常・異常・変更検知・コピー抑止）
- README（英語・日本語）、design.md を更新