### PR TITLE
fix: remove pull_request rule parameters to fix API 422 error

### DIFF
--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -156,12 +156,7 @@ RULESET_BODY='{
     { "type": "deletion" },
     { "type": "non_fast_forward" },
     { "type": "required_linear_history" },
-    { "type": "pull_request", "parameters": {
-        "required_approving_review_count": 0,
-        "dismiss_stale_reviews_on_push": false,
-        "require_last_push_approval": false,
-        "required_review_thread_resolution": false
-    }}
+    { "type": "pull_request" }
   ]
 }'
 


### PR DESCRIPTION
## Summary

- Rulesets の `pull_request` ルールから明示的なパラメータを削除（API 422 エラーの修正）
- GitHub API がパラメータなしで `required_approving_review_count: 0` 等のデフォルト値を自動設定することを確認
- `setup-repo.sh` の実行と冪等性を dev-config リポジトリで実証済み