### PR TITLE
feat: add pr-check workflow to shared

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,8 @@ shared/              -> 全リポジトリに同期（毎回上書き）
   .editorconfig      -> エディタ共通設定
   .gitattributes     -> 改行コード正規化
   .mdformat.toml     -> Markdown フォーマッター設定
+  .github/workflows/
+    pr-check.yaml    -> PR タイトル・ブランチ名検証
 templates/           -> 初期セットアップ用（存在しない場合のみコピー）
   CLAUDE.md
   SECURITY.md
@@ -83,6 +85,7 @@ setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト
 | 設定 | .editorconfig | エディタ共通設定 |
 | 設定 | .gitattributes | 改行コード正規化 |
 | 設定 | .mdformat.toml | Markdown フォーマッター設定 |
+| ワークフロー | .github/workflows/pr-check.yaml | PR タイトル・ブランチ名の Conventional Commits 検証 |
 
 ## テンプレート
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ shared/              -> Synced to every repo (always overwrite)
   .editorconfig      -> Editor settings
   .gitattributes     -> Line ending normalization
   .mdformat.toml     -> Markdown formatter config
+  .github/workflows/
+    pr-check.yaml    -> PR title & branch name validation
 templates/           -> Copied on initial setup only (if not exists)
   CLAUDE.md
   SECURITY.md
@@ -83,6 +85,7 @@ Sets merge rules (squash only), branch protection (Rulesets), security settings,
 | Config | .editorconfig | Editor settings (charset, indent, line ending) |
 | Config | .gitattributes | Line ending normalization, binary detection |
 | Config | .mdformat.toml | Markdown formatter config |
+| Workflow | .github/workflows/pr-check.yaml | PR title & branch name Conventional Commits validation |
 
 ## What is templated
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -58,6 +58,7 @@ templates/.claude/settings.json        → <repo>/.claude/settings.json
 | .editorconfig | エディタ共通設定（文字コード、改行、インデント） |
 | .gitattributes | 改行コード正規化、バイナリファイル判定 |
 | .mdformat.toml | Markdown フォーマッター設定 |
+| .github/workflows/pr-check.yaml | PR タイトル・ブランチ名の Conventional Commits 検証 |
 
 ## テンプレート一覧
 

--- a/shared/.github/workflows/pr-check.yaml
+++ b/shared/.github/workflows/pr-check.yaml
@@ -1,0 +1,55 @@
+name: PR Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-title-check:
+    name: PR Title Format Check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check PR title format
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?:.+/;
+
+            if (!pattern.test(title)) {
+              core.setFailed(
+                `PR title does not follow Conventional Commits format.\n\n` +
+                `Expected format: type(scope): description\n` +
+                `Valid types: feat, fix, docs, style, refactor, perf, test, chore\n\n` +
+                `Current title: ${title}`
+              );
+            } else {
+              core.info('PR title follows Conventional Commits format');
+            }
+
+  branch-name-check:
+    name: Branch Name Check
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check branch name format
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)\/.+/;
+
+            if (branch === 'main') {
+              core.info('Branch is main, skipping check');
+              return;
+            }
+
+            if (!pattern.test(branch)) {
+              core.setFailed(
+                `Branch name does not follow naming convention.\n\n` +
+                `Expected format: type/description\n` +
+                `Valid types: feat, fix, docs, style, refactor, perf, test, chore\n\n` +
+                `Current branch: ${branch}`
+              );
+            } else {
+              core.info('Branch name follows naming convention');
+            }

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -15,6 +15,8 @@ setup() {
   echo "shared editorconfig" > "${SRC_DIR}/shared/.editorconfig"
   echo "shared gitattributes" > "${SRC_DIR}/shared/.gitattributes"
   echo "shared mdformat" > "${SRC_DIR}/shared/.mdformat.toml"
+  mkdir -p "${SRC_DIR}/shared/.github/workflows"
+  echo "shared pr-check" > "${SRC_DIR}/shared/.github/workflows/pr-check.yaml"
   echo "template lint" > "${SRC_DIR}/templates/.claude/skills/lint-rules/SKILL.md"
   echo "template claude" > "${SRC_DIR}/templates/CLAUDE.md"
   echo "template security" > "${SRC_DIR}/templates/SECURITY.md"


### PR DESCRIPTION
## Summary

- `shared/.github/workflows/pr-check.yaml` を追加: PR タイトルとブランチ名の Conventional Commits 検証ワークフロー
  - git-workflow.md のルールを GitHub Actions で強制
  - 破壊的変更 (`!`) にも対応（ozzylabs.com 版の漏れを修正）
  - sync で全リポに配布され、ルール変更時に一括反映される
- docs/design.md: shared 一覧に追加
- README（英語・日本語）: 構成ツリーとテーブルを更新
- tests/sync.bats: setup にファイルを追加