### PR TITLE
fix: sync missing shared files and expand yamlfmt lint coverage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Normalize all text files to LF
+* text=auto eol=lf
+
+# Lock files
+pnpm-lock.yaml linguist-generated=true
+
+# Binary files
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
+*.zip binary
+*.tar.gz binary
+*.pdf binary

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,2 @@
+wrap = "no"
+end_of_line = "lf"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "lefthook install || true",
     "lint:md": "markdownlint-cli2 '**/*.md' '!node_modules'",
-    "lint:yaml": "yamlfmt -lint .commitlintrc.yaml .yamlfmt.yaml .yamllint.yaml lefthook.yaml shared/lefthook-base.yaml shared/.commitlintrc.yaml && yamllint -c .yamllint.yaml .",
+    "lint:yaml": "yamlfmt -lint . && yamllint -c .yamllint.yaml .",
     "lint:shell": "find . -name '*.sh' -not -path './node_modules/*' -exec shellcheck {} + && find . -name '*.sh' -not -path './node_modules/*' -exec shfmt -d {} +",
     "lint:secrets": "gitleaks detect --no-banner",
     "lint:all": "pnpm run lint:md && pnpm run lint:yaml && pnpm run lint:shell && pnpm run lint:secrets",


### PR DESCRIPTION
## Summary

- root に欠落していた shared ファイル 3 つ（.editorconfig, .gitattributes, .mdformat.toml）を同期し、CI の `sync.sh --check .` 失敗を解消
- `lint:yaml` の yamlfmt を明示ファイルリストから `yamlfmt -lint .` に変更し、全 YAML ファイル（workflows, templates, markdownlint config）をカバー