### PR TITLE
fix: enforce space after colon in PR title regex, explicit ruleset params, and test coverage

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?:.+/;
+            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?:\s.+/;
 
             if (!pattern.test(title)) {
               core.setFailed(

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -158,7 +158,14 @@ RULESET_BODY='{
     { "type": "deletion" },
     { "type": "non_fast_forward" },
     { "type": "required_linear_history" },
-    { "type": "pull_request" }
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_last_push_approval": false
+      }
+    }
   ]
 }'
 

--- a/shared/.github/workflows/pr-check.yaml
+++ b/shared/.github/workflows/pr-check.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           script: |
             const title = context.payload.pull_request.title;
-            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?:.+/;
+            const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\(.+\))?!?:\s.+/;
 
             if (!pattern.test(title)) {
               core.setFailed(

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -8,6 +8,7 @@ setup() {
   mkdir -p "${SRC_DIR}/shared/.claude/skills/commit"
   mkdir -p "${SRC_DIR}/shared/.claude/rules"
   mkdir -p "${SRC_DIR}/templates/.claude/skills/lint-rules"
+  mkdir -p "${SRC_DIR}/templates/.claude"
   echo "shared skill" > "${SRC_DIR}/shared/.claude/skills/commit/SKILL.md"
   echo "shared rule" > "${SRC_DIR}/shared/.claude/rules/git-workflow.md"
   echo "shared lefthook" > "${SRC_DIR}/shared/lefthook-base.yaml"
@@ -37,6 +38,8 @@ setup() {
   mkdir -p "${SRC_DIR}/templates/.vscode"
   echo "template vscode settings" > "${SRC_DIR}/templates/.vscode/settings.json"
   echo "template vscode extensions" > "${SRC_DIR}/templates/.vscode/extensions.json"
+  echo "template lefthook" > "${SRC_DIR}/templates/lefthook.yaml"
+  echo "template settings" > "${SRC_DIR}/templates/.claude/settings.json"
 
   # Init as git repo (needed for metadata commit hash)
   git -C "${SRC_DIR}" init -q


### PR DESCRIPTION
## Summary

- PR タイトル検証の正規表現でコロン後のスペースを必須にする（Conventional Commits 準拠）
- `setup-repo.sh` の Rulesets `pull_request` ルールにパラメータを明示（API デフォルト依存を排除）
- `sync.bats` テストセットアップに不足していたテンプレート 2 件（`lefthook.yaml`, `.claude/settings.json`）を追加