### PR TITLE
fix: harden sync/setup scripts, pin zsh plugins, and expand test coverage

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,11 +16,19 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # Install mise
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://mise.run | sh
 
-# Install oh-my-zsh plugins (static layer — placed before mise install for better caching)
+# Install oh-my-zsh plugins (pinned to known commits)
 RUN git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
         ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+        fetch --depth=1 origin 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5 \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+        checkout 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5 \
     && git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
         ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+        fetch --depth=1 origin 1d85c692615a25fe2293bdd44b34c217d5d2bf04 \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+        checkout 1d85c692615a25fe2293bdd44b34c217d5d2bf04 \
     && sed -i 's/^plugins=(git)$/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' ~/.zshrc
 
 # Install tools defined in .mise.toml (cached in image layer)

--- a/dist/.devcontainer/Dockerfile
+++ b/dist/.devcontainer/Dockerfile
@@ -16,11 +16,19 @@ RUN curl -fsSL https://claude.ai/install.sh | bash
 # Install mise
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://mise.run | sh
 
-# Install oh-my-zsh plugins (static layer — placed before mise install for better caching)
+# Install oh-my-zsh plugins (pinned to known commits)
 RUN git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions \
         ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+        fetch --depth=1 origin 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5 \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions \
+        checkout 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5 \
     && git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting \
         ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+        fetch --depth=1 origin 1d85c692615a25fe2293bdd44b34c217d5d2bf04 \
+    && git -C ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting \
+        checkout 1d85c692615a25fe2293bdd44b34c217d5d2bf04 \
     && sed -i 's/^plugins=(git)$/plugins=(git zsh-autosuggestions zsh-syntax-highlighting)/' ~/.zshrc
 
 # Install tools defined in .mise.toml (cached in image layer)

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -141,7 +141,7 @@ echo "3. Branch protection (Rulesets)"
 RULESET_NAME="main-protection"
 
 # Check if ruleset already exists
-EXISTING_RULESET_ID="$(gh api "/repos/${REPO}/rulesets" --jq ".[] | select(.name == \"${RULESET_NAME}\") | .id" 2>/dev/null || true)"
+EXISTING_RULESET_ID="$(gh api "/repos/${REPO}/rulesets" --jq "[.[] | select(.name == \"${RULESET_NAME}\") | .id] | first" 2>/dev/null || true)"
 
 RULESET_BODY='{
   "name": "'"${RULESET_NAME}"'",

--- a/sync.sh
+++ b/sync.sh
@@ -72,7 +72,14 @@ read_pinned() {
     fi
     if ${in_pinned}; then
       if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
-        echo "${BASH_REMATCH[1]}"
+        local val="${BASH_REMATCH[1]}"
+        # Strip surrounding quotes and trailing whitespace
+        val="${val#\"}"
+        val="${val%\"}"
+        val="${val#\'}"
+        val="${val%\'}"
+        val="${val%"${val##*[! ]}"}"
+        echo "${val}"
       else
         break
       fi
@@ -101,6 +108,7 @@ write_metadata() {
   fi
   SYNCED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
+  local tmp_file="${METADATA_FILE}.tmp.$$"
   {
     echo "# Auto-updated by dev-config sync.sh"
     echo "# 'pinned' is user-editable — add or remove paths freely"
@@ -112,7 +120,7 @@ write_metadata() {
         echo "  - ${p}"
       done
     fi
-  } >"${METADATA_FILE}"
+  } >"${tmp_file}" && mv "${tmp_file}" "${METADATA_FILE}"
 }
 
 # --- Collect files ---

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -19,7 +19,6 @@ setup() {
   echo "commitlint" > "${SRC_DIR}/dist/.commitlintrc.yaml"
   echo "editorconfig" > "${SRC_DIR}/dist/.editorconfig"
   echo "gitattributes" > "${SRC_DIR}/dist/.gitattributes"
-  echo "mdformat" > "${SRC_DIR}/dist/.mdformat.toml"
   echo "pr-check" > "${SRC_DIR}/dist/.github/workflows/pr-check.yaml"
   echo "claude md" > "${SRC_DIR}/dist/CLAUDE.md"
   echo "security" > "${SRC_DIR}/dist/SECURITY.md"
@@ -262,4 +261,62 @@ EOF
   meta="$(cat "${TARGET_DIR}/.dev-config/sync.yaml")"
   [[ "$meta" == *"pinned:"* ]]
   [[ "$meta" == *"CLAUDE.md"* ]]
+}
+
+@test "pinned files with YAML quotes are recognized" {
+  "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+
+  # Pin CLAUDE.md with YAML double quotes
+  mkdir -p "${TARGET_DIR}/.dev-config"
+  cat > "${TARGET_DIR}/.dev-config/sync.yaml" <<'EOF'
+commit: abc1234
+synced_at: 2026-04-05T00:00:00Z
+pinned:
+  - "CLAUDE.md"
+EOF
+
+  echo "my custom claude" > "${TARGET_DIR}/CLAUDE.md"
+  echo "updated claude md" > "${SRC_DIR}/dist/CLAUDE.md"
+
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${TARGET_DIR}/CLAUDE.md")" = "my custom claude" ]
+}
+
+@test "pinned files with trailing spaces are recognized" {
+  "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+
+  # Pin CLAUDE.md with trailing spaces
+  mkdir -p "${TARGET_DIR}/.dev-config"
+  printf 'commit: abc1234\nsynced_at: 2026-04-05T00:00:00Z\npinned:\n  - CLAUDE.md   \n' \
+    > "${TARGET_DIR}/.dev-config/sync.yaml"
+
+  echo "my custom claude" > "${TARGET_DIR}/CLAUDE.md"
+  echo "updated claude md" > "${SRC_DIR}/dist/CLAUDE.md"
+
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${TARGET_DIR}/CLAUDE.md")" = "my custom claude" ]
+}
+
+@test "metadata is written atomically via temp file" {
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ -f "${TARGET_DIR}/.dev-config/sync.yaml" ]
+  # No leftover temp files
+  local tmp_count
+  tmp_count="$(find "${TARGET_DIR}/.dev-config" -name 'sync.yaml.tmp.*' | wc -l)"
+  [ "$tmp_count" -eq 0 ]
+}
+
+@test "interactive mode: skip unchanged and respond to input" {
+  "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+
+  echo "updated skill" > "${SRC_DIR}/dist/.claude/skills/commit/SKILL.md"
+  echo "updated claude md" > "${SRC_DIR}/dist/CLAUDE.md"
+
+  # Provide "n" to skip the first changed file, then "y" for the second
+  run bash -c 'printf "n\ny\n" | "${1}" "${2}"' _ "${SRC_DIR}/sync.sh" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sync complete."* ]]
 }


### PR DESCRIPTION
## Summary

レビューで「許容」と判断していた残改善候補 6 件を一括対応。

### sync.sh の堅牢性向上
- `read_pinned` が YAML 引用符（`"`, `'`）と末尾スペースを正しく除去するよう修正
- メタデータ書き込みを一時ファイル経由のアトミック操作に変更（中断時のデータ消失を防止）

### setup-repo.sh のエッジケース対策
- 同名ルールセットが複数存在する場合に備え、jq で `first` を使用

### サプライチェーン強化
- oh-my-zsh プラグイン（zsh-autosuggestions, zsh-syntax-highlighting）をコミット SHA にピン

### テストカバレッジ拡充（15 → 20 シナリオ）
- 引用符付き pin の認識テスト
- 末尾スペース付き pin の認識テスト
- アトミックメタデータ書き込みの検証テスト
- 対話モードの基本動作テスト
- テストフィクスチャから削除済み `.mdformat.toml` を除去