### PR TITLE
fix(setup): add missing pull_request ruleset parameters

### DIFF
--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -163,7 +163,9 @@ RULESET_BODY='{
       "parameters": {
         "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": false,
-        "require_last_push_approval": false
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
       }
     }
   ]


### PR DESCRIPTION
## Summary

- Add `require_code_owner_review` and `required_review_thread_resolution` parameters to the pull_request ruleset in `setup-repo.sh`
- These parameters are required by the GitHub API for complete ruleset configuration