### PR TITLE
feat(renovate): migrate to shared org preset

### DIFF
--- a/dist/renovate.json
+++ b/dist/renovate.json
@@ -1,22 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
-  "minimumReleaseAge": "3 days",
-  "automergeType": "pr",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "devDependencies (non-major)",
-      "matchUpdateTypes": ["patch", "minor"]
-    }
-  ]
+  "extends": ["github>ozzy-labs/.github"]
 }


### PR DESCRIPTION
## Summary

- Org レベルの Renovate shared preset を `ozzy-labs/.github` に作成
- `dist/renovate.json` を shared preset 参照 (`github>ozzy-labs/.github`) に書き換え
- `create-agentic-dev` / `create-agentic-aws` も同様に更新（別 PR）
  - https://github.com/ozzy-labs/create-agentic-dev/pull/168
  - https://github.com/ozzy-labs/create-agentic-aws/pull/487

Closes #34