### PR TITLE
feat: add .mdformat.toml to dist

### DIFF
--- a/dist/.mdformat.toml
+++ b/dist/.mdformat.toml
@@ -1,0 +1,2 @@
+wrap = "no"
+end_of_line = "lf"

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -13,6 +13,7 @@ taplo = "0.10"
 yamlfmt = "0.21"
 actionlint = "1"
 gitleaks = "8"
+"pipx:mdformat" = "0.7"
 
 # Git hooks
 lefthook = "2"


### PR DESCRIPTION
## Summary

- agentic-dev-template の `.mdformat.toml` を `dist/` に追加（`wrap=no`, `end_of_line=lf`）
- `.mise.toml` に `pipx:mdformat` を追加

Closes #35