### PR TITLE
feat: add minimal Trivy config to dist

### DIFF
--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -13,6 +13,7 @@ taplo = "0.10"
 yamlfmt = "0.21"
 actionlint = "1"
 gitleaks = "8"
+trivy = "0.62"
 "pipx:mdformat" = "0.7"
 
 # Git hooks

--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -30,3 +30,5 @@ pre-commit:
       stage_fixed: true
     gitleaks:
       run: gitleaks protect --staged --no-banner
+    trivy:
+      run: trivy fs --scanners vuln,secret --exit-code 1 --no-progress .

--- a/dist/trivy.yaml
+++ b/dist/trivy.yaml
@@ -1,0 +1,8 @@
+scan:
+  scanners:
+    - vuln
+    - secret
+  skip-dirs:
+    - node_modules
+    - .pnpm-store
+    - .venv


### PR DESCRIPTION
## Summary

- `dist/trivy.yaml` を追加（vuln + secret スキャナーのみ、IaC/コンテナは各リポでカスタマイズ）
- `.mise.toml` に `trivy` を追加
- `lefthook-base.yaml` の pre-commit に trivy fs スキャンを追加

Closes #36