### PR TITLE
fix: add missing trivy and mdformat to tool configs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,6 +36,8 @@
       "Bash(taplo *)",
       "Bash(actionlint *)",
       "Bash(gitleaks *)",
+      "Bash(trivy *)",
+      "Bash(mdformat *)",
       "Bash(bats *)",
       "Bash(gh auth *)",
       "Bash(gh api *)",

--- a/.claude/skills/lint-rules/SKILL.md
+++ b/.claude/skills/lint-rules/SKILL.md
@@ -32,3 +32,9 @@ pnpm run typecheck
 ```bash
 gitleaks detect --no-banner
 ```
+
+全ファイルを対象に Trivy で脆弱性・シークレットスキャンを実行する:
+
+```bash
+trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+```

--- a/.mise.toml
+++ b/.mise.toml
@@ -13,6 +13,8 @@ taplo = "0.10"
 yamlfmt = "0.21"
 actionlint = "1"
 gitleaks = "8"
+trivy = "0.69"
+"pipx:mdformat" = "0.7"
 
 # Testing
 "npm:bats" = "1"

--- a/dist/.claude/settings.json
+++ b/dist/.claude/settings.json
@@ -36,6 +36,8 @@
       "Bash(taplo *)",
       "Bash(actionlint *)",
       "Bash(gitleaks *)",
+      "Bash(trivy *)",
+      "Bash(mdformat *)",
       "Bash(bats *)",
       "Bash(gh auth *)",
       "Bash(gh api *)"

--- a/dist/.claude/skills/lint-rules/SKILL.md
+++ b/dist/.claude/skills/lint-rules/SKILL.md
@@ -32,3 +32,9 @@ pnpm run typecheck
 ```bash
 gitleaks detect --no-banner
 ```
+
+全ファイルを対象に Trivy で脆弱性・シークレットスキャンを実行する:
+
+```bash
+trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+```

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -13,7 +13,7 @@ taplo = "0.10"
 yamlfmt = "0.21"
 actionlint = "1"
 gitleaks = "8"
-trivy = "0.62"
+trivy = "0.69"
 "pipx:mdformat" = "0.7"
 
 # Git hooks

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -30,3 +30,5 @@ pre-commit:
       stage_fixed: true
     gitleaks:
       run: gitleaks protect --staged --no-banner
+    trivy:
+      run: trivy fs --scanners vuln,secret --exit-code 1 --no-progress .


### PR DESCRIPTION
## Summary

#35, #36 で追加した trivy / mdformat に関する整合性漏れを修正:

- `settings.json`（root・dist）に `Bash(trivy *)`, `Bash(mdformat *)` 権限を追加
- root `.mise.toml` に trivy / mdformat を追加（dev-config 自身の開発環境に反映）
- root `lefthook-base.yaml` に trivy フックを追加（dist 版と同期）
- `lint-rules/SKILL.md`（root・dist）に trivy コマンドを追記
- trivy バージョンを 0.62（存在しない）→ 0.69 に修正