### PR TITLE
feat: add AGENTS.md as shared instructions and slim down CLAUDE.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,8 @@ dist/                -> 全リポジトリに配布
     rules/           -> ルール
     settings.json    -> 許可ツール・権限設定
   .devcontainer/     -> devcontainer 設定
+  .gemini/
+    settings.json    -> Gemini CLI 設定（AGENTS.md を読み込む）
   .github/
     workflows/       -> PR タイトル・ブランチ名検証
     ISSUE_TEMPLATE/  -> Issue テンプレート
@@ -26,7 +28,8 @@ dist/                -> 全リポジトリに配布
   .mdformat.toml     -> Markdown フォーマッター設定
   .mise.toml         -> ツールバージョン管理
   trivy.yaml         -> Trivy セキュリティスキャナー設定
-  CLAUDE.md          -> プロジェクト概要の雛形
+  AGENTS.md          -> AI エージェント共通 instructions の雛形
+  CLAUDE.md          -> Claude Code 固有設定
   ...
 sync.sh              -> 同期スクリプト
 setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ dist/                -> Distributed to every repo
     rules/           -> Rules
     settings.json    -> Allowed tools and permissions
   .devcontainer/     -> Devcontainer config
+  .gemini/
+    settings.json    -> Gemini CLI config (loads AGENTS.md)
   .github/
     workflows/       -> PR title & branch name validation
     ISSUE_TEMPLATE/  -> Issue templates
@@ -26,7 +28,8 @@ dist/                -> Distributed to every repo
   .mdformat.toml     -> Markdown formatter config
   .mise.toml         -> Tool version management
   trivy.yaml         -> Trivy security scanner config
-  CLAUDE.md          -> Project overview template
+  AGENTS.md          -> Shared AI agent instructions template
+  CLAUDE.md          -> Claude Code specific config
   ...
 sync.sh              -> Sync script
 setup-repo.sh        -> GitHub repository setup script

--- a/dist/.gemini/settings.json
+++ b/dist/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["AGENTS.md"]
+  }
+}

--- a/dist/AGENTS.md
+++ b/dist/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md
+
+このファイルは AI エージェント向けの共通 instructions です。
+
+## 基本方針
+
+- 日本語で応答する
+- 推奨案とその理由を提示する
+- `.env` ファイルは読み取り・ステージングしない
+- 破壊的な Git 操作を避ける
+
+## プロジェクト概要
+
+`<project-name>`: <description>
+
+## Tech Stack
+
+- Runtime: Node.js (ESM)
+- Package manager: pnpm
+- Version management: mise (`.mise.toml`)
+
+## 主要コマンド
+
+```bash
+pnpm install               # 依存関係インストール
+pnpm run dev               # 開発サーバー起動
+pnpm run build             # プロダクションビルド
+```
+
+## 検証（必須）
+
+コード変更後、報告前に以下を通すこと:
+
+1. `pnpm run build` — ビルド成功
+2. `pnpm run typecheck` — 型チェック通過
+
+## コーディング規約
+
+- インデント: 2 スペース
+- 改行コード: LF
+- ファイル末尾: 改行あり
+
+## 規約
+
+言語・コミット・ブランチ・PR のルールは README.md を参照すること。
+
+## Adapter Files
+
+| Agent | Configuration |
+|-------|---------------|
+| Claude Code | `CLAUDE.md`, `.claude/` |
+| Gemini CLI | `.gemini/settings.json` → `AGENTS.md` |
+| Codex CLI | `AGENTS.md` + `.agents/skills/` |
+| GitHub Copilot | `AGENTS.md` + `.agents/skills/` |

--- a/dist/CLAUDE.md
+++ b/dist/CLAUDE.md
@@ -1,24 +1,23 @@
 # CLAUDE.md
 
-## プロジェクト概要
+共通方針は AGENTS.md を参照。以下は Claude Code 固有の設定。
 
-`<project-name>`: <description>
+## 基本ルール
 
-## 主要コマンド
+- ユーザーへの確認には `AskUserQuestion` を使用する
 
-```bash
-pnpm install               # 依存関係インストール
-pnpm run dev               # 開発サーバー起動
-pnpm run build             # プロダクションビルド
-```
+## Available Skills
 
-## 検証（必須）
+- `/implement` — Issue または指示をもとに、ブランチ作成・実装
+- `/lint` — 全リンターを自動修正付きで実行
+- `/test` — ビルド・テスト・型チェックを実行
+- `/commit` — 変更をステージし、Conventional Commits でコミット
+- `/pr` — 変更を push し、PR を作成・更新
+- `/review` — コード変更や PR をレビュー
+- `/ship` — lint・コミット・PR 作成を一括実行
+- `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）
 
-コード変更後、報告前に以下を通すこと:
+## Skills の共通ルール
 
-1. `pnpm run build` — ビルド成功
-2. `pnpm run typecheck` — 型チェック通過
-
-## 規約
-
-言語・コミット・ブランチ・PR のルールは README.md を参照すること。
+- スキル完了時のネクストアクション提案には `AskUserQuestion` を使用する
+- ネクストアクションはユーザーの確認なく実行しない


### PR DESCRIPTION
## Summary

- `dist/AGENTS.md` を追加（AI エージェント共通の instructions テンプレート）
- `dist/CLAUDE.md` を AGENTS.md 参照 + Claude Code 固有設定のみに薄化
- `dist/.gemini/settings.json` を追加（Gemini CLI が AGENTS.md を読む設定）
- `.mcp.json` は現状維持（context7 を継続配布）

Closes #44