### PR TITLE
feat: add Codex CLI and Gemini CLI to devcontainer

### DIFF
--- a/dist/.devcontainer/Dockerfile
+++ b/dist/.devcontainer/Dockerfile
@@ -39,6 +39,10 @@ RUN ~/.local/bin/mise trust /home/vscode/.mise.toml \
     && ~/.local/bin/mise install \
     && rm /home/vscode/.mise.toml
 
+# Install AI agent CLIs (npm available after mise installs Node.js)
+RUN eval "$(/home/vscode/.local/bin/mise activate bash)" \
+    && npm install -g @openai/codex @google/gemini-cli
+
 # Switch back to root for remaining setup
 USER root
 RUN chsh -s /bin/zsh vscode \


### PR DESCRIPTION
## Summary

- Codex CLI (`@openai/codex`) と Gemini CLI (`@google/gemini-cli`) を devcontainer の Dockerfile に追加
- mise install 後に npm install -g で導入（Node.js が必要なため）
- GitHub Copilot CLI は gh 組み込みのため追加不要

これにより devcontainer で 4 エージェント全て（Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI）が利用可能になる。

Closes #50