### PR TITLE
feat: add scheduled sync workflow for consumer repos

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -71,6 +71,18 @@ setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト
 
 マージルール（squash のみ）、ブランチ保護（Rulesets）、セキュリティ設定、Conventional Commits ラベルを設定する。設計方針は [ADR-0004](docs/adr/0004-repo-setup-with-rulesets.md) を参照。
 
+### 自動同期（定期 PR）
+
+各消費リポには `.github/workflows/sync-dev-config.yaml` が配布される。このワークフローは毎週（月曜 UTC 00:00）と手動起動で動作し、最新の `dev-config` と比較して差分があれば `sync.sh --yes` を実行し、プルリクエストを作成する。自動マージはせず、必ずレビューしてマージする。
+
+Renovate ではなく scheduled workflow にした理由: Renovate の組込 manager は「独自スクリプトで sibling repo からファイルをコピーする」モデルをサポートしない。Custom `regexManagers` で commit SHA は追跡できるが `sync.sh` 自体の実行は別手段が必要で、`postUpgradeTasks` は Mend Renovate GitHub App では使えない（self-hosted 限定）。Scheduled GitHub Actions なら既存の `sync.sh` / `.dev-config/sync.yaml` の設計を生かしたまま自動化できる。
+
+消費リポ側の初回セットアップ手順:
+
+1. 手動で一度 `sync.sh` を実行し、`sync-dev-config.yaml` を `.github/workflows/` に取り込む
+2. リポ設定で PR 作成が許可されていること（`setup-repo.sh` 実行済みなら OK）
+3. 翌週から scheduled で自動起動。`workflow_dispatch` で即時実行も可能
+
 ## リポジトリ固有のまま残すもの
 
 - ドメイン固有のスキル・ルール

--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ When a file is intentionally customized in a target repo, it can be **pinned** t
 
 Sets merge rules (squash only), branch protection (Rulesets), security settings, and Conventional Commits labels. See [ADR-0004](docs/adr/0004-repo-setup-with-rulesets.md) for design decisions.
 
+### Automated sync (scheduled PR)
+
+Consumer repos get a workflow distributed at `.github/workflows/sync-dev-config.yaml`. It runs weekly (Monday 00:00 UTC) and on manual dispatch, checks the repo against the latest `dev-config`, and — if any non-pinned file diverges — runs `sync.sh --yes` and opens a pull request. Review and merge manually; the workflow never auto-merges.
+
+Why a scheduled workflow and not Renovate: Renovate's built-in managers don't cover the "copy files from a sibling repo via a custom script" model. Custom `regexManagers` could track the commit SHA but can't execute `sync.sh`, and `postUpgradeTasks` is unavailable on the Mend Renovate GitHub App (self-hosted only). A scheduled GitHub Actions workflow fits the existing `sync.sh` / `.dev-config/sync.yaml` design without adding a second source of truth.
+
+First-time setup for a consumer repo:
+
+1. Run `sync.sh` manually once to pick up `sync-dev-config.yaml` into `.github/workflows/`
+2. The repo settings must allow creating PRs (already the case if `setup-repo.sh` was run)
+3. The weekly schedule takes over from the next Monday; `workflow_dispatch` lets you trigger it on demand
+
 ## What stays in each repo
 
 - Domain-specific skills and rules

--- a/dist/.github/workflows/sync-dev-config.yaml
+++ b/dist/.github/workflows/sync-dev-config.yaml
@@ -1,0 +1,74 @@
+name: Sync dev-config
+
+# Automated sync of shared configuration from ozzy-labs/dev-config.
+#
+# Runs on a weekly schedule (configurable) and on manual dispatch. When
+# the upstream dev-config repo has changes that are not yet reflected
+# in this repo (per `.dev-config/sync.yaml` state, minus `pinned`
+# entries), the workflow runs `sync.sh --yes` and opens a pull request
+# with the resulting diff. The PR is never auto-merged; review it.
+#
+# Prerequisites in the consumer repo:
+#   - Workflow permissions must allow creating PRs (usually set by
+#     dev-config/setup-repo.sh)
+#   - `.dev-config/sync.yaml` exists (created on first manual sync.sh run)
+on:
+  schedule:
+    # Every Monday 00:00 UTC
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync dev-config defaults
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Clone dev-config
+        uses: actions/checkout@v4
+        with:
+          repository: ozzy-labs/dev-config
+          path: .sync-dev-config
+          fetch-depth: 1
+
+      - name: Detect diff and run sync
+        id: sync
+        run: |
+          set -e
+          if bash .sync-dev-config/sync.sh --check "$GITHUB_WORKSPACE"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to sync."
+            exit 0
+          fi
+          bash .sync-dev-config/sync.sh --yes "$GITHUB_WORKSPACE"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Remove temporary clone
+        if: steps.sync.outputs.changed == 'true'
+        run: rm -rf .sync-dev-config
+
+      - name: Create Pull Request
+        if: steps.sync.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/sync-dev-config
+          base: main
+          commit-message: |
+            chore: sync dev-config defaults
+
+            Automated sync from ozzy-labs/dev-config.
+          title: "chore: sync dev-config defaults"
+          body: |
+            Automated sync from [ozzy-labs/dev-config](https://github.com/ozzy-labs/dev-config).
+
+            Files listed under `pinned` in `.dev-config/sync.yaml` are excluded.
+
+            Triggered by the scheduled `Sync dev-config` workflow. Review the diff and merge when appropriate.
+          labels: chore
+          delete-branch: true


### PR DESCRIPTION
## Summary

Distribute a GitHub Actions workflow that automates dev-config sync in every consumer repo.

- `dist/.github/workflows/sync-dev-config.yaml` — new workflow
- `README.md` / `README.ja.md` — design rationale and first-time setup

## What it does

- Runs weekly (Monday 00:00 UTC) and on manual dispatch
- Clones `ozzy-labs/dev-config` and runs `sync.sh --check`
- If any non-pinned file diverges, runs `sync.sh --yes` and opens a PR via `peter-evans/create-pull-request@v7`
- Never auto-merges — review is required

## Why not Renovate

Renovate's built-in managers don't cover "copy files from a sibling repo via a custom script":

- Custom `regexManagers` can track a commit SHA but can't execute `sync.sh`
- `postUpgradeTasks` is unavailable on the Mend Renovate GitHub App (self-hosted only)

A scheduled GitHub Actions workflow keeps `sync.sh` + `.dev-config/sync.yaml` as the single source of truth. The full rationale is in the README sections *Automated sync (scheduled PR)* / *自動同期（定期 PR）*.

## First-time adoption

Each consumer repo needs **one manual `sync.sh` run** to pick up the new workflow file into `.github/workflows/`. From the next Monday the schedule takes over. This bootstrap step is documented in the README.

## Changes

- `dist/.github/workflows/sync-dev-config.yaml` (new, 76 lines)
- `README.md` (new section *Automated sync (scheduled PR)*)
- `README.ja.md` (new section *自動同期（定期 PR）*)

## Follow-up (not in this PR)

- Pin third-party actions (`actions/checkout@v4`, `peter-evans/create-pull-request@v7`) to commit SHAs for security. Consistent with the existing `pr-check.yaml` that pins `actions/github-script` to SHA. Can be added once adoption is validated; Renovate / Dependabot can keep SHAs current afterward
- Consider an ADR if operational experience over a few weeks reveals design trade-offs worth recording

## Type of Change

- [x] New feature
- [x] CI/CD

## Testing

- [x] `markdownlint-cli2 --fix README.md README.ja.md` → 0 errors
- [x] `yamllint -c .yamllint.yaml dist/.github/workflows/sync-dev-config.yaml` → 0 errors
- [x] lefthook pre-commit passed
- [x] commitlint passed

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed