### PR TITLE
fix: skip comments and blank lines inside pinned block

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -71,6 +71,10 @@ read_pinned() {
       continue
     fi
     if ${in_pinned}; then
+      # Skip blank lines and YAML comments interleaved within the pinned block
+      if [[ -z "${line}" ]] || [[ "${line}" =~ ^[[:space:]]*# ]]; then
+        continue
+      fi
       if [[ "${line}" =~ ^[[:space:]]*-[[:space:]]+(.*) ]]; then
         local val="${BASH_REMATCH[1]}"
         # Strip surrounding quotes and trailing whitespace

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -343,6 +343,44 @@ EOF
   [[ "$output" == *"pinned:"*".editorconfig"* ]]
 }
 
+@test "pinned parser skips interleaved comments and blank lines" {
+  "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+
+  mkdir -p "${TARGET_DIR}/.dev-config"
+  cat > "${TARGET_DIR}/.dev-config/sync.yaml" <<'EOF'
+commit: abc1234
+synced_at: 2026-04-05T00:00:00Z
+pinned:
+  # first group: customised on purpose
+  - CLAUDE.md
+
+  # second group: blocked upstream updates
+  - .editorconfig
+  - trivy.yaml
+EOF
+
+  echo "my claude" > "${TARGET_DIR}/CLAUDE.md"
+  echo "my editor" > "${TARGET_DIR}/.editorconfig"
+  echo "my trivy" > "${TARGET_DIR}/trivy.yaml"
+
+  echo "updated claude md" > "${SRC_DIR}/dist/CLAUDE.md"
+  echo "updated editorconfig" > "${SRC_DIR}/dist/.editorconfig"
+  echo "updated trivy" > "${SRC_DIR}/dist/trivy.yaml"
+
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+
+  # All three pinned entries, including the ones after comments/blank lines,
+  # must be recognised and preserved.
+  [ "$(cat "${TARGET_DIR}/CLAUDE.md")" = "my claude" ]
+  [ "$(cat "${TARGET_DIR}/.editorconfig")" = "my editor" ]
+  [ "$(cat "${TARGET_DIR}/trivy.yaml")" = "my trivy" ]
+
+  [[ "$output" == *"pinned:"*"CLAUDE.md"* ]]
+  [[ "$output" == *"pinned:"*".editorconfig"* ]]
+  [[ "$output" == *"pinned:"*"trivy.yaml"* ]]
+}
+
 @test "metadata is written atomically via temp file" {
   run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
   [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

`sync.sh`'s `read_pinned()` broke out of the pinned section on any line that didn't match `- <path>`. Any YAML comment or blank line inside the pinned list silently cut off **every entry after it**, so those files were no longer treated as pinned and could be overwritten by the next `sync.sh -y`.

## How this was discovered

During handbook setup, the following `.dev-config/sync.yaml` was written:

```yaml
pinned:
  # Code-specific tooling not needed for a Markdown-only handbook
  - biome.json
  - .mise.toml
  - trivy.yaml
  # Dev container not needed for handbook authoring
  - .devcontainer/Dockerfile
  ...
```

After running `sync.sh --check`, the tools reported **everything after the first comment line** as "new" / out of sync — because the parser stopped reading the pinned list at the first comment. Moving the comments outside the `pinned:` block (to the header of the file) worked around the issue, but hid a bug that could cause data loss for users grouping pins with rationale.

## Fix

Inside the pinned block:

- **Skip** empty lines and lines starting with `#` (YAML comment)
- **Break** only on non-list, non-comment, non-blank lines — preserves the original boundary detection for the case where another top-level YAML key follows `pinned:`

## Regression test

Added `pinned parser skips interleaved comments and blank lines` to `tests/sync.bats`: pins three files with comments and blank lines between them, runs `sync.sh -y`, and asserts all three stay unchanged. Reliably fails on the old parser.

## Changes

- `sync.sh` (5 lines in `read_pinned()`)
- `tests/sync.bats` (+37 lines, 1 new test)

## Testing

- [x] `bats tests/sync.bats` — 27/27 pass (including new test)
- [x] `shellcheck sync.sh` — clean
- [x] `shfmt -d sync.sh` — clean
- [x] lefthook pre-commit passed
- [x] commitlint passed

## Type of Change

- [x] Bug fix

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed