### PR TITLE
feat(renovate): add commons-sync preset and full-SHA sync metadata

### DIFF
--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -1,6 +1,6 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 6a8bffd
+commit: 6a8bffd85447424da27a9e52b04d411e61fef155
 synced_at: 2026-04-18T07:06:22Z
 pinned:
   - .claude/settings.json

--- a/README.ja.md
+++ b/README.ja.md
@@ -75,13 +75,26 @@ setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト
 
 各消費リポには `.github/workflows/sync-commons.yaml` が配布される。このワークフローは毎週（月曜 UTC 00:00）と手動起動で動作し、最新の `commons` と比較して差分があれば `sync.sh --yes` を実行し、プルリクエストを作成する。自動マージはせず、必ずレビューしてマージする。
 
-Renovate ではなく scheduled workflow にした理由: Renovate の組込 manager は「独自スクリプトで sibling repo からファイルをコピーする」モデルをサポートしない。Custom `regexManagers` で commit SHA は追跡できるが `sync.sh` 自体の実行は別手段が必要で、`postUpgradeTasks` は Mend Renovate GitHub App では使えない（self-hosted 限定）。Scheduled GitHub Actions なら既存の `sync.sh` / `.dev-config/sync.yaml` の設計を生かしたまま自動化できる。
-
 消費リポ側の初回セットアップ手順:
 
 1. 手動で一度 `sync.sh` を実行し、`sync-commons.yaml` を `.github/workflows/` に取り込む
 2. リポ設定で PR 作成が許可されていること（`setup-repo.sh` 実行済みなら OK）
 3. 翌週から scheduled で自動起動。`workflow_dispatch` で即時実行も可能
+
+### Renovate 経由の自動同期（opt-in）
+
+週次 schedule の代替として、consumer リポは `commons-sync` Renovate preset を `extends` することで低レイテンシな更新検知に切り替えられる。Renovate は commons の `main` ブランチ HEAD を追跡し、新しい commit が来ると `.dev-config/sync.yaml` の `commit:` フィールドを書き換える PR を consumer に送る。実ファイルの反映は consumer 側の workflow が `sync.sh --yes` を Renovate PR ブランチ上で実行する役割。
+
+Consumer の `renovate.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ozzy-labs/commons:commons-sync"]
+}
+```
+
+設計の詳細は [ADR-0006](docs/adr/0006-renovate-auto-sync-preset.md) を参照。consumer 側の workflow 整備は Renovate PoC の roll-out（handbook#18 / handbook#42）で対応予定。それまでは scheduled workflow が推奨パス。
 
 ## リポジトリ固有のまま残すもの
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,26 @@ Sets merge rules (squash only), branch protection (Rulesets), security settings,
 
 Consumer repos get a workflow distributed at `.github/workflows/sync-commons.yaml`. It runs weekly (Monday 00:00 UTC) and on manual dispatch, checks the repo against the latest `commons`, and — if any non-pinned file diverges — runs `sync.sh --yes` and opens a pull request. Review and merge manually; the workflow never auto-merges.
 
-Why a scheduled workflow and not Renovate: Renovate's built-in managers don't cover the "copy files from a sibling repo via a custom script" model. Custom `regexManagers` could track the commit SHA but can't execute `sync.sh`, and `postUpgradeTasks` is unavailable on the Mend Renovate GitHub App (self-hosted only). A scheduled GitHub Actions workflow fits the existing `sync.sh` / `.dev-config/sync.yaml` design without adding a second source of truth.
-
 First-time setup for a consumer repo:
 
 1. Run `sync.sh` manually once to pick up `sync-commons.yaml` into `.github/workflows/`
 2. The repo settings must allow creating PRs (already the case if `setup-repo.sh` was run)
 3. The weekly schedule takes over from the next Monday; `workflow_dispatch` lets you trigger it on demand
+
+### Automated sync via Renovate (opt-in)
+
+As a lower-latency alternative to the weekly schedule, consumer repos can opt into the `commons-sync` Renovate preset. Renovate watches the commons `main` branch and opens a PR bumping `.dev-config/sync.yaml`'s `commit:` field whenever a new commit lands. Actual file materialisation remains the consumer workflow's job (it runs `sync.sh --yes` on the Renovate PR branch).
+
+Consumer `renovate.json`:
+
+```json
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>ozzy-labs/commons:commons-sync"]
+}
+```
+
+Design details are in [ADR-0006](docs/adr/0006-renovate-auto-sync-preset.md). Consumer-side workflow integration is tracked by the Renovate PoC rollout (handbook#18 / handbook#42); until that lands, the scheduled workflow above is the supported path.
 
 ## What stays in each repo
 

--- a/commons-sync.json
+++ b/commons-sync.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "description": "Auto-sync commons (ozzy-labs) via Renovate customManagers + git-refs. See https://github.com/ozzy-labs/commons/blob/main/docs/adr/0006-renovate-auto-sync-preset.md",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["**/.dev-config/sync.yaml"],
+      "matchStrings": ["commit:\\s*(?<currentDigest>[a-f0-9]{7,40})"],
+      "currentValueTemplate": "main",
+      "depNameTemplate": "ozzy-labs/commons",
+      "packageNameTemplate": "https://github.com/ozzy-labs/commons",
+      "datasourceTemplate": "git-refs"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchDepNames": ["ozzy-labs/commons"],
+      "matchDatasources": ["git-refs"],
+      "commitMessageTopic": "commons",
+      "commitMessageExtra": "to {{newDigestShort}}",
+      "labels": ["chore", "commons-sync"],
+      "semanticCommits": "enabled",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
+    }
+  ]
+}

--- a/docs/adr/0006-renovate-auto-sync-preset.md
+++ b/docs/adr/0006-renovate-auto-sync-preset.md
@@ -1,0 +1,79 @@
+# ADR-0006: Renovate Auto-Sync Preset for Consumer Repos
+
+## Status
+
+Accepted (2026-04-25)
+
+Relates to: [handbook ADR-0002](https://github.com/ozzy-labs/handbook/blob/main/adr/0002-skills-distribution-via-renovate.md) (skills distribution via Renovate)
+
+Parent issue: [handbook#18](https://github.com/ozzy-labs/handbook/issues/18)
+
+## Context
+
+[ADR-0005](./0005-unified-dist-with-pin.md) で `dist/` を `sync.sh` で全リポへ配布する方式が確立している。現在は各消費リポの `.github/workflows/sync-commons.yaml` が週次（月曜 UTC 00:00）で `sync.sh --check` → 差分があれば `sync.sh --yes` → PR 作成を行う。
+
+handbook ADR-0002 は「共通 skill / 設定は Renovate 自動同期で配布する」ことを決定した。動機:
+
+- 週次 schedule では更新反映までに最大 1 週間のラグがある
+- schedule 起動は手動 dispatch 以外に「いつ来るか分からない」
+- Renovate の方が事実上のデファクト（依存更新は他も Renovate 管理）であり、同じメンタルモデルに統合できる
+
+ただし Renovate の built-in manager は「sibling repo から sync.sh でファイルをコピーする」モデルを直接サポートしない。`postUpgradeTasks` は Mend Renovate GitHub App では使えない（self-hosted 限定）。したがって Renovate 単体では物理的なファイルコピーはできない。
+
+## Decision
+
+**Renovate を commons の更新検知器として使い、物理コピーは consumer 側の workflow に委譲する。**
+
+commons 側のスコープ（この ADR）:
+
+1. 消費リポが `extends` で参照できる preset を `ozzy-labs/commons` に commit する
+2. preset は customManager で `.dev-config/sync.yaml` の `commit:` フィールドを監視する
+3. datasource は `git-refs` を使い、`https://github.com/ozzy-labs/commons` の `main` ブランチ HEAD を追跡する
+4. Renovate は新しい SHA を検知したら `commit:` だけを書き換えた PR を consumer に送る
+
+### 具体ファイル
+
+- `commons-sync.json` — preset 本体（リポ直下）
+  - consumer は `{ "extends": ["github>ozzy-labs/commons:commons-sync"] }` で参照
+- `sync.sh` — `commit:` を full 40 文字 SHA で書き込むよう変更
+  - Renovate `git-refs` datasource は full SHA を返すため、short SHA だと毎 sync で format 往復が発生する
+
+### Pinned との衝突回避
+
+- Renovate が書き換えるのは `commit:` のみ。`pinned:` リストは正規表現の match 対象外で無改変に保たれる
+- 実 sync を担う workflow（consumer 側）が `sync.sh --yes` を実行する際、sync.sh は `.dev-config/sync.yaml` を読み直して `pinned` をそのまま引き継いで再書き込みするため、pinned セマンティクスは保たれる
+
+### スコープ外（別 sub-issue）
+
+- 消費リポへの実際の roll-out は [handbook#42](https://github.com/ozzy-labs/handbook/issues/42) で 1 リポ opt-in 試験
+- Renovate PR を受けて `sync.sh --yes` を走らせる workflow の consumer 向け配布は roll-out フェーズで整備する
+
+## Alternatives considered
+
+- **`github-tags` / `github-releases` datasource** — commons は tag / release を運用していない。採用するなら運用設計が先行する
+- **`postUpgradeTasks` で sync.sh を実行する** — Mend Renovate GitHub App で使えない。self-hosted 移行は別議論
+- **`.dev-config/sync.yaml` ではなく別の marker ファイル（例: `.dev-config/commons.version`）** — ファイル数が増え、sync.sh / metadata 既存ロジックとの整合も増える。commit: フィールドは既に "currently synced version" を表現しているので流用が自然
+- **scheduled workflow を廃止して Renovate に一本化** — 初期は併存。opt-in で 1 リポ試験、問題がなければ後続 ADR で整理
+
+## Consequences
+
+### Positive
+
+- commons の更新反映ラグが「最大 1 週間」→ 「Renovate の schedule 粒度（デフォルト 1 時間程度）」に短縮可能
+- 既存の `.dev-config/sync.yaml` / `sync.sh` / `pinned` 設計を変えずに乗せられる
+- preset として配布されるため、consumer の renovate.json への追加は 1 行
+
+### Negative / Trade-offs
+
+- `git-refs` が `main` ブランチ全コミットを追跡するため、`dist/` 非タッチのコミットでも PR が飛ぶ。consumer の sync workflow が空差分を no-op として扱う必要がある（handbook#42 で対応）
+- preset だけでは機能しない（consumer の workflow 整備が必要）。ドキュメントで明示する
+- short SHA → full SHA への format 移行が必要。既存 consumer の `.dev-config/sync.yaml` は次回 `sync.sh` 実行時に自動で full SHA に書き換わる
+
+## References
+
+- [handbook ADR-0002](https://github.com/ozzy-labs/handbook/blob/main/adr/0002-skills-distribution-via-renovate.md) — skills distribution via Renovate
+- [handbook#18](https://github.com/ozzy-labs/handbook/issues/18) — Renovate auto-sync PoC（parent issue）
+- [handbook#42](https://github.com/ozzy-labs/handbook/issues/42) — 1 リポ opt-in 試験（sibling sub-issue）
+- [ADR-0005](./0005-unified-dist-with-pin.md) — `dist/` + pin による同期設計
+- [Renovate customManagers docs](https://docs.renovatebot.com/modules/manager/regex/)
+- [Renovate git-refs datasource docs](https://docs.renovatebot.com/modules/datasource/git-refs/)

--- a/sync.sh
+++ b/sync.sh
@@ -106,7 +106,7 @@ write_metadata() {
   local pinned_list=("$@")
   mkdir -p "${METADATA_DIR}"
 
-  if ! COMMIT_HASH="$(git -C "${SCRIPT_DIR}" rev-parse --short HEAD 2>/dev/null)"; then
+  if ! COMMIT_HASH="$(git -C "${SCRIPT_DIR}" rev-parse HEAD 2>/dev/null)"; then
     echo "Warning: commons is not a git repository. Skipping metadata." >&2
     return
   fi

--- a/tests/commons-sync-preset.bats
+++ b/tests/commons-sync-preset.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+# Smoke-test the Renovate preset file exposed to consumer repos. Validates
+# JSON syntax and the core contract fields that consumers depend on.
+
+PRESET_FILE="${BATS_TEST_DIRNAME}/../commons-sync.json"
+
+@test "preset file exists at repo root" {
+  [ -f "${PRESET_FILE}" ]
+}
+
+@test "preset is valid JSON" {
+  jq -e . "${PRESET_FILE}" >/dev/null
+}
+
+@test "preset declares the renovate \$schema" {
+  jq -e '."$schema" | test("renovate-schema")' "${PRESET_FILE}" >/dev/null
+}
+
+@test "preset defines a customManager targeting .dev-config/sync.yaml" {
+  jq -e '.customManagers[0].managerFilePatterns | map(test("sync\\.yaml")) | any' \
+    "${PRESET_FILE}" >/dev/null
+}
+
+@test "preset customManager captures currentDigest via regex" {
+  jq -e '.customManagers[0].matchStrings | map(test("currentDigest")) | any' \
+    "${PRESET_FILE}" >/dev/null
+}
+
+@test "preset uses git-refs datasource pointing at ozzy-labs/commons main" {
+  [ "$(jq -r '.customManagers[0].datasourceTemplate' "${PRESET_FILE}")" = "git-refs" ]
+  jq -e '.customManagers[0].packageNameTemplate | test("ozzy-labs/commons")' \
+    "${PRESET_FILE}" >/dev/null
+  [ "$(jq -r '.customManagers[0].currentValueTemplate' "${PRESET_FILE}")" = "main" ]
+}

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -135,10 +135,10 @@ teardown() {
   meta="$(cat "${TARGET_DIR}/.dev-config/sync.yaml")"
   [[ "$meta" == *"commit: "* ]]
   [[ "$meta" == *"synced_at: "* ]]
-  # Verify commit hash is a valid short hash (hex chars)
+  # Verify commit hash is a full 40-char hex SHA (Renovate git-refs compatible)
   local hash
   hash="$(grep '^commit:' "${TARGET_DIR}/.dev-config/sync.yaml" | awk '{print $2}')"
-  [[ "$hash" =~ ^[0-9a-f]+$ ]]
+  [[ "$hash" =~ ^[0-9a-f]{40}$ ]]
 }
 
 @test "metadata includes user-editable comment" {


### PR DESCRIPTION
## Summary

- ozzy-labs/commons の自動同期に向けた Renovate preset (`commons-sync.json`) を新設。consumer は `extends: ["github>ozzy-labs/commons:commons-sync"]` で opt-in 可能
- `customManagers` + `git-refs` datasource で `.dev-config/sync.yaml` の `commit:` フィールドを追跡し、main ブランチの新コミットで PR を自動発行
- `pinned` 衝突回避: Renovate は `commit:` のみ書き換え、sync.sh が `pinned:` をそのまま再書き出しするため意図的乖離は保たれる
- `sync.sh` を full 40-char SHA 書き込みに変更（git-refs 互換、format 往復回避）
- 設計判断は [ADR-0006](docs/adr/0006-renovate-auto-sync-preset.md) に記録
- 実 roll-out（consumer workflow 整備、1 リポ opt-in 試験）はスコープ外（[handbook#42](https://github.com/ozzy-labs/handbook/issues/42)）

## Validation

- `bats tests/` 全 44 件通過（preset 用 6 件追加）
- `pnpm run lint:all` 通過
- `renovate-config-validator --no-global --strict commons-sync.json` 通過

Closes #60
Refs handbook#18, handbook ADR-0002

🤖 Generated with [Claude Code](https://claude.com/claude-code)