### PR TITLE
ci: pass GITHUB_TOKEN to mise-action and disable trivy in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,27 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      # trivy is a local-only security scanner (lefthook pre-commit / dev use).
+      # CI lint/test does not need it, and resolving aqua:aquasecurity/trivy
+      # releases via GitHub API has been hitting 403 (secondary rate limit /
+      # auth scope) even with GITHUB_TOKEN set. Skip install in CI entirely.
+      # See handbook#84 / commons#73.
+      MISE_DISABLE_TOOLS: trivy
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          install: true
+          cache: true
+          # Explicit token: authenticates mise's aqua / GitHub release lookups
+          # (defaults exist but normalize for clarity and future repo rollout).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          # Belt-and-suspenders: some mise backends (aqua) read GITHUB_TOKEN
+          # from env rather than the action input.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

`mise-action` step が `aqua:aquasecurity/trivy` の release lookup で chronic に 403 を返し、commons#70 / commons#72 で `--admin` bypass merge を強いられていた問題を解消する（[handbook#84](https://github.com/ozzy-labs/handbook/issues/84) PoC、Closes #73）。

## Root cause

直近 fail run（[run 24941759442](https://github.com/ozzy-labs/commons/actions/runs/24941759442)）の log を確認した結果:

- `mise-action` は **既に** `GITHUB_TOKEN=***` を env / input にセットしている（v2 のデフォルト挙動）
- それにも関わらず `mise install` が以下で失敗:
  ```
  WARN  [aquasecurity/trivy] failed to fetch version tags, URL may be incorrect:
        HTTP status client error (403 Forbidden) for url
        (https://api.github.com/repos/aquasecurity/trivy/releases)
  ERROR Failed to install aqua:aquasecurity/trivy@0.69
  ```
- つまり handbook#84 の **方針 A（token を渡す）単独では不十分**。token は既に渡っているのに 403 を踏んでいる（aqua backend の secondary rate limit / paginated probe が原因と推測）

## Fix

方針 A + B を両方適用:

1. **`MISE_DISABLE_TOOLS: trivy` を job level env に設定**（方針 B）
   - trivy は lefthook pre-commit / dev 用途のみで、`pnpm run lint:all` / `pnpm run test` は trivy を使わないため CI install は完全に無駄
   - install 自体を skip すれば 403 を踏みようがなく、CI の信頼性が確実に上がる
2. **`github_token: ${{ secrets.GITHUB_TOKEN }}` を `with:` に明示**（方針 A、normalization）
   - 既に default で設定されているが、他 repo 展開時に統一パターンとして diff から自明にする
3. **`GITHUB_TOKEN` を step env にも設定**（belt-and-suspenders）
   - mise の aqua backend は input ではなく env から token を読む経路があるため両方に出す

## Verification

- [x] `mise exec -- actionlint .github/workflows/ci.yaml` クリーン
- [x] `mise exec -- lefthook run pre-commit --all-files` クリーン
- [ ] **本 PR の CI が green**（このアサーションが本 PR の存在意義 — `--admin` bypass merge せず緑になることを確認）

## Rollout note for handbook#84

token を渡すだけでは 403 が解消しないことが本 PoC で判明したため、他 repo（handbook / skills / presets / ...）に展開する際は **必ず `MISE_DISABLE_TOOLS: trivy` を伴わせる** 必要がある。trivy が CI で本当に必要な repo（もしあれば）は別途方針 C（install 元切替）を検討する。

## Related

- Closes #73
- Refs [handbook#84](https://github.com/ozzy-labs/handbook/issues/84)（親）
- Refs [commons#70](https://github.com/ozzy-labs/commons/pull/70) / [commons#72](https://github.com/ozzy-labs/commons/pull/72)（観測 PR）