### PR TITLE
fix(sync): resolve dist/root self-sync drift

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,9 +40,7 @@
       "Bash(mdformat *)",
       "Bash(bats *)",
       "Bash(gh auth *)",
-      "Bash(gh api *)",
-      "Bash(./sync.sh *)",
-      "Bash(./setup-repo.sh *)"
+      "Bash(gh api *)"
     ]
   }
 }

--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,0 +1,4 @@
+# Auto-updated by commons sync.sh
+# 'pinned' is user-editable — add or remove paths freely
+commit: 15f6e772b1291e6c55e05cd46529e1271d52f21d
+synced_at: 2026-04-25T22:18:32Z

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,4 +46,7 @@ jobs:
         run: ./sync.sh --check .
 
       - name: Test
+        env:
+          # gh CLI tests in tests/setup-repo.bats (11-18) require auth.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,10 +14,27 @@ permissions:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    env:
+      # trivy is a local-only security scanner (lefthook pre-commit / dev use).
+      # CI lint/test does not need it, and resolving aqua:aquasecurity/trivy
+      # releases via GitHub API has been hitting 403 (secondary rate limit /
+      # auth scope) even with GITHUB_TOKEN set. Skip install in CI entirely.
+      # See handbook#84 / commons#73.
+      MISE_DISABLE_TOOLS: trivy
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+        with:
+          install: true
+          cache: true
+          # Explicit token: authenticates mise's aqua / GitHub release lookups
+          # (defaults exist but normalize for clarity and future repo rollout).
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          # Belt-and-suspenders: some mise backends (aqua) read GITHUB_TOKEN
+          # from env rather than the action input.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/sync-commons.yaml
+++ b/.github/workflows/sync-commons.yaml
@@ -1,0 +1,74 @@
+name: Sync commons
+
+# Automated sync of shared configuration from ozzy-labs/commons.
+#
+# Runs on a weekly schedule (configurable) and on manual dispatch. When
+# the upstream commons repo has changes that are not yet reflected
+# in this repo (per `.commons/sync.yaml`, minus `pinned` entries), the
+# workflow runs `sync.sh --yes` and opens a pull request with the
+# resulting diff. The PR is never auto-merged; review it.
+#
+# Prerequisites in the consumer repo:
+#   - Workflow permissions must allow creating PRs (usually set by
+#     commons/setup-repo.sh)
+#   - `.commons/sync.yaml` exists (created on first manual sync.sh run).
+on:
+  schedule:
+    # Every Monday 00:00 UTC
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync commons defaults
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Clone commons
+        uses: actions/checkout@v4
+        with:
+          repository: ozzy-labs/commons
+          path: .sync-commons
+          fetch-depth: 1
+
+      - name: Detect diff and run sync
+        id: sync
+        run: |
+          set -e
+          if bash .sync-commons/sync.sh --check "$GITHUB_WORKSPACE"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to sync."
+            exit 0
+          fi
+          bash .sync-commons/sync.sh --yes "$GITHUB_WORKSPACE"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Remove temporary clone
+        if: steps.sync.outputs.changed == 'true'
+        run: rm -rf .sync-commons
+
+      - name: Create Pull Request
+        if: steps.sync.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/sync-commons
+          base: main
+          commit-message: |
+            chore: sync commons defaults
+
+            Automated sync from ozzy-labs/commons.
+          title: "chore: sync commons defaults"
+          body: |
+            Automated sync from [ozzy-labs/commons](https://github.com/ozzy-labs/commons).
+
+            Files listed under `pinned` in `.commons/sync.yaml` are excluded.
+
+            Triggered by the scheduled `Sync commons` workflow. Review the diff and merge when appropriate.
+          labels: chore
+          delete-branch: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,17 @@ Thumbs.db
 *.swp
 *~
 
+# Environment
+.env
+.env.*
+!.env.example
+
 # Dependencies
 node_modules/
+
+# Build
+dist/
+build/
+
+# Logs
+*.log

--- a/.mise.toml
+++ b/.mise.toml
@@ -17,14 +17,14 @@ gitleaks = "8"
 trivy = "0.69"
 "pipx:mdformat" = "0.7"
 
+# Testing
+"npm:bats" = "1"
+
 # CLI utilities for AI-assisted development
 ast-grep = "0.42"
 yq = "4"
 just = "1"
 zoxide = "0.9"
-
-# Testing
-"npm:bats" = "1"
 
 # Git hooks & commit conventions
 lefthook = "2"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "biomejs.biome",
+    "DavidAnson.vscode-markdownlint",
+    "EditorConfig.EditorConfig",
+    "foxundermoon.shell-format",
+    "github.vscode-github-actions",
+    "redhat.vscode-yaml",
+    "tamasfe.even-better-toml",
+    "timonwong.shellcheck"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,42 @@
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.biome": "explicit"
+  },
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "search.exclude": {
+    "**/dist": true
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[markdown]": {
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "explicit"
+    }
+  },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  }
+}

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -17,6 +17,9 @@ gitleaks = "8"
 trivy = "0.69"
 "pipx:mdformat" = "0.7"
 
+# Testing
+"npm:bats" = "1"
+
 # CLI utilities for AI-assisted development
 ast-grep = "0.42"
 yq = "4"

--- a/tests/sync-no-fallback.bats
+++ b/tests/sync-no-fallback.bats
@@ -15,6 +15,8 @@ setup() {
   echo "editor" > "${SRC_DIR}/dist/.editorconfig"
 
   git -C "${SRC_DIR}" init -q
+  git -C "${SRC_DIR}" config user.email "test@example.com"
+  git -C "${SRC_DIR}" config user.name "Test User"
   git -C "${SRC_DIR}" add .
   git -C "${SRC_DIR}" commit -q -m "init"
 
@@ -24,6 +26,8 @@ setup() {
   TARGET_DIR="${TEST_DIR}/target"
   mkdir -p "${TARGET_DIR}"
   git -C "${TARGET_DIR}" init -q
+  git -C "${TARGET_DIR}" config user.email "test@example.com"
+  git -C "${TARGET_DIR}" config user.name "Test User"
   git -C "${TARGET_DIR}" commit -q --allow-empty -m "init"
 }
 

--- a/tests/sync-skills.bats
+++ b/tests/sync-skills.bats
@@ -46,6 +46,8 @@ EOF
   TARGET_DIR="${TEST_DIR}/target"
   mkdir -p "${TARGET_DIR}"
   git -C "${TARGET_DIR}" init -q
+  git -C "${TARGET_DIR}" config user.email "test@example.com"
+  git -C "${TARGET_DIR}" config user.name "Test User"
   git -C "${TARGET_DIR}" commit -q --allow-empty -m "init"
 
   # AGENTS.md with marker block

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -43,6 +43,8 @@ setup() {
 
   # Init as git repo (needed for metadata commit hash)
   git -C "${SRC_DIR}" init -q
+  git -C "${SRC_DIR}" config user.email "test@example.com"
+  git -C "${SRC_DIR}" config user.name "Test User"
   git -C "${SRC_DIR}" add .
   git -C "${SRC_DIR}" commit -q -m "init"
 
@@ -54,6 +56,8 @@ setup() {
   TARGET_DIR="${TEST_DIR}/target"
   mkdir -p "${TARGET_DIR}"
   git -C "${TARGET_DIR}" init -q
+  git -C "${TARGET_DIR}" config user.email "test@example.com"
+  git -C "${TARGET_DIR}" config user.name "Test User"
   git -C "${TARGET_DIR}" commit -q --allow-empty -m "init"
 }
 


### PR DESCRIPTION
## Summary

- `./sync.sh --check .` was failing on main with 1 new + 3 changed files, blocking commons#74 from going CI-green. Drift was baked in by admin-bypass merges (#70, #72) that landed without the self-sync check passing.
- Apply `./sync.sh --yes .` to make root mirror `dist/` for `.claude/settings.json`, `.gitignore`, `.mise.toml`, and the new `.github/workflows/sync-commons.yaml`.
- Add `npm:bats` to `dist/.mise.toml` so dist gains the test tooling commons itself needs (`pnpm run test` runs bats). Without this, `--yes` would have stripped bats from root and broken the `Test` step in CI. Bats is small and useful for any consumer that wants shell tests.
- Track `.commons/sync.yaml` metadata generated by sync.sh (per the `Sync commons` workflow's expectations).
- **Fold in the `ci.yaml` fix from #74** (pass `GITHUB_TOKEN` to `jdx/mise-action` and set `MISE_DISABLE_TOOLS: trivy`) to break the circular CI dependency between #74 and this PR. Once this PR lands, #74 and issue #73 will be closed as superseded.

## Local verification

- `./sync.sh --check .` exits 0 on this branch.
- `mise exec -- actionlint` — clean.
- `mise exec -- lefthook run pre-commit --all-files` — all hooks pass.

## Resolution of circular dependency with commons#74

Originally, CI on this PR failed at the `mise install` step with the **trivy 403** error that commons#74 was designed to fix, while #74 itself failed at the `Check shared files are self-synced` step that this PR fixes. Each PR needed the other to go green.

Per option 2 in the prior discussion, the small `ci.yaml` change from #74 has been folded in here as a single, targeted CI-only commit (`ci: pass GITHUB_TOKEN to mise-action and disable trivy install`). This PR can now go green on its own without `--admin` bypass.

After merge:
- #74 will be closed as superseded.
- #73 (the underlying issue tracked by #74) will be closed as superseded.

## Test plan

- [ ] CI `mise install` green (verifies the folded `ci.yaml` fix).
- [ ] CI `Check shared files are self-synced` green (the key gate for this issue).
- [ ] CI `Test` (bats) green — verifies bats still installs via mise after the dist tweak.

## Out of scope

- (none — the trivy 403 fix is now in scope and folded in.)

Closes #75
Closes #73
Refs handbook#84, commons#74
