### PR TITLE
test(setup-repo): make test 16 visibility-agnostic

### DIFF
--- a/tests/setup-repo.bats
+++ b/tests/setup-repo.bats
@@ -56,10 +56,15 @@ setup() {
   [[ "$output" == *"Repository: ozzy-labs/commons"* ]]
 }
 
-@test "--dry-run skips private vulnerability reporting for private repo" {
+@test "--dry-run handles private vulnerability reporting based on visibility" {
+  VISIBILITY="$(gh repo view ozzy-labs/commons --json visibility --jq '.visibility')"
   run "${SCRIPT}" --dry-run ozzy-labs/commons
   [ "$status" -eq 0 ]
-  [[ "$output" == *"skipped (private repo)"* ]]
+  if [[ "${VISIBILITY}" == "PUBLIC" ]]; then
+    [[ "$output" == *"Private vulnerability reporting: enabled"* ]]
+  else
+    [[ "$output" == *"skipped (private repo)"* ]]
+  fi
 }
 
 @test "--dry-run shows all 10 Conventional Commits labels" {


### PR DESCRIPTION
Fixes #77. Updates test 16 in `setup-repo.bats` to be visibility-agnostic by checking the actual visibility of the repository. This allows the tests to pass on the now-public `commons` repository.