### PR TITLE
fix(ci): skip branch-name-check on release-please auto PRs

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -47,6 +47,11 @@ jobs:
               return;
             }
 
+            if (branch.startsWith('release-please--')) {
+              core.info('Branch is a release-please auto PR, skipping check');
+              return;
+            }
+
             if (!pattern.test(branch)) {
               core.setFailed(
                 `Branch name does not follow naming convention.\n\n` +

--- a/dist/.github/workflows/pr-check.yaml
+++ b/dist/.github/workflows/pr-check.yaml
@@ -48,6 +48,11 @@ jobs:
               return;
             }
 
+            if (branch.startsWith('release-please--')) {
+              core.info('Branch is a release-please auto PR, skipping check');
+              return;
+            }
+
             if (!pattern.test(branch)) {
               core.setFailed(
                 `Branch name does not follow naming convention.\n\n` +


### PR DESCRIPTION
## Summary

- `branch-name-check` ジョブが release-please-action の auto PR (例: `release-please--branches--main--components--<pkg>`) で必ず fail していた問題を修正
- branch 名が `release-please--` で始まる場合、`main` と同じく早期 return で skip するよう変更
- dist テンプレート（consumer リポへ同期される）と commons リポ自身の CI 用ルートワークフローの両方を更新

Closes #89

## Test plan

- [x] `pnpm test`（bats 90 件）pass
- [x] `pnpm run lint:yaml` / `lint:shell` pass
- [x] `pre-commit` hook (yamlfmt / yamllint / trivy / gitleaks / commitlint) pass
- [ ] このリポ自体の `Branch Name Check` (本 PR) が pass する
- [ ] sync 後、consumer リポ (gh-tasks 等) で release-please PR の `Branch Name Check` が pass する

## Notes

- Issue で言及されていた dependabot 等の他 auto-PR ボット対応は別 ADR で議論する想定で、今回のスコープには含めない