### PR TITLE
chore(workflows): bump action versions and unify branch-name-check skips

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -37,10 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
+            const actor = context.payload.pull_request.user?.login ?? '';
             const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)\/.+/;
 
             if (branch === 'main') {
@@ -50,6 +51,11 @@ jobs:
 
             if (branch.startsWith('release-please--')) {
               core.info('Branch is a release-please auto PR, skipping check');
+              return;
+            }
+
+            if (actor === 'dependabot[bot]' || branch.startsWith('dependabot/')) {
+              core.info(`Branch is managed by Dependabot (${branch}), skipping check`);
               return;
             }
 

--- a/.github/workflows/sync-commons.yaml
+++ b/.github/workflows/sync-commons.yaml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone commons
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ozzy-labs/commons
           path: .sync-commons
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.sync.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/sync-commons
           base: main

--- a/dist/.github/workflows/pr-check.yaml
+++ b/dist/.github/workflows/pr-check.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -37,10 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
+            const actor = context.payload.pull_request.user?.login ?? '';
             const pattern = /^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)\/.+/;
 
             if (branch === 'main') {
@@ -50,6 +51,11 @@ jobs:
 
             if (branch.startsWith('release-please--')) {
               core.info('Branch is a release-please auto PR, skipping check');
+              return;
+            }
+
+            if (actor === 'dependabot[bot]' || branch.startsWith('dependabot/')) {
+              core.info(`Branch is managed by Dependabot (${branch}), skipping check`);
               return;
             }
 

--- a/dist/.github/workflows/sync-commons.yaml
+++ b/dist/.github/workflows/sync-commons.yaml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Clone commons
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ozzy-labs/commons
           path: .sync-commons
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create Pull Request
         if: steps.sync.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           branch: chore/sync-commons
           base: main


### PR DESCRIPTION
## Summary

`dist/.github/workflows/{pr-check,sync-commons}.yaml`（および root の同名ファイル）を全 consumer の Renovate / 独自更新と整合させる。

### Changes

- **`pr-check.yaml`**
  - `actions/github-script` v8 → v9.0.0
  - `branch-name-check` で Dependabot の auto PR を skip（actor=`dependabot[bot]` または branch=`dependabot/*`）— road / ozzylabs.com の独自ロジックを統合
- **`sync-commons.yaml`**
  - `actions/checkout` v4 → v6
  - `peter-evans/create-pull-request` v7 → v8
- **root と dist の同期**: `dist/.github/workflows/*.yaml` を root の `.github/workflows/*.yaml` にも適用（commons 自身の self-sync を待たずに即時反映）

### Why

- 13 consumer のうち ozzylabs.com / road が Renovate 由来でアクションバージョンを先行更新しており、commons 正本が drift している
- `branch-name-check` の Dependabot 対応も同じ理由で consumer 側に分散

### Follow-up

マージ後、全 13 consumer に新 dist を `cp` で伝搬する作業が別途必要（starlight-theme は独自 Build & Typecheck ジョブ分離 PR を先に処理）。

Closes #96

## Test plan

- [ ] CI（pr-check / lint / bats）pass