### PR TITLE
fix(ci): pin uv to 0.11.8 to avoid attestation verification failure

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -2,7 +2,7 @@
 # Runtime & package managers
 node = "24"
 pnpm = "10"
-uv = "0.11"
+uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see #98)
 
 # Linters & formatters
 biome = "2"

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -2,7 +2,7 @@
 # Runtime & package managers
 node = "24"
 pnpm = "10"
-uv = "0.11"
+uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters
 biome = "2"


### PR DESCRIPTION
## Summary

uv 0.11.9 (released today, 2026-05-05) fails GitHub Artifact Attestation verification in `jdx/mise-action`:

```
expected 'astral-sh/uv/.github/workflows/release.yml',
found certificate: None, provenance: None
```

Pinning `uv = "0.11.8"` in both root and dist `.mise.toml` to unblock CI.

## Why both files

- root `.mise.toml`: commons own CI
- `dist/.mise.toml`: propagated to all consumers on next sync — without this, every consumer's CI would also break

Closes #98

## Test plan

- [ ] CI (ci job) passes on this PR