### PR TITLE
fix(ci): switch pnpm install backend from aqua to npm

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Runtime & package managers
 node = "24"
-pnpm = "10"
+"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see #100)
 uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see #98)
 
 # Linters & formatters

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Runtime & package managers
 node = "24"
-pnpm = "10"
+"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
 uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters


### PR DESCRIPTION
## Summary

aqua registry update broke install of pnpm v10:

```
Failed to install aqua:pnpm/pnpm@10: no asset found: pnpm-linux-x64.tar.gz
```

Registry expects v11 `.tar.gz` format; v10.x ships bare binaries. Switch to `npm:pnpm` backend.

## Why both files

- root `.mise.toml`: commons own CI
- `dist/.mise.toml`: propagated to all consumers — needed to keep their CI working too

Closes #100

## Test plan

- [ ] CI passes (mise install + lint + test)