### PR TITLE
fix(ci): align root .mise.toml comment with dist for self-sync check

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 # Runtime & package managers
 node = "24"
-"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see #100)
-uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see #98)
+"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters
 biome = "2"


### PR DESCRIPTION
## Summary

`sync.sh --check` requires root and dist files to match exactly. PR #99 / #101 introduced different issue-reference styles between root and dist `.mise.toml`:

- root: `see #100`
- dist: `see ozzy-labs/commons#100`

Use full cross-repo references in both files (matches dist style, unambiguous when propagated to consumers).

## Test plan

- [x] `bash sync.sh --check .` passes locally → `All files are up to date.`
- [ ] CI passes