### PR TITLE
fix(sync): wrap copilot-instructions.md in commons markers

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # GitHub Copilot Instructions
 
 共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
@@ -26,3 +27,4 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+<!-- end: ozzy-labs/commons -->

--- a/dist/.github/copilot-instructions.md
+++ b/dist/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # GitHub Copilot Instructions
 
 共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
@@ -26,3 +27,4 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+<!-- end: ozzy-labs/commons -->


### PR DESCRIPTION
Wraps `dist/.github/copilot-instructions.md` (and the synced root copy) in `<!-- begin/end: ozzy-labs/commons -->` so commons sync uses marker-merge mode and preserves `@ozzylabs/skills` marker sections in consumer files.

Closes #104

## Test plan

- [x] `bash sync.sh --check .` passes locally
- [ ] CI passes