### PR TITLE
fix(dist): pad commons markers with blank lines for prettier

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,5 @@
 <!-- begin: ozzy-labs/commons -->
+
 # GitHub Copilot Instructions
 
 共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
@@ -27,4 +28,5 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+
 <!-- end: ozzy-labs/commons -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 <!-- begin: ozzy-labs/commons -->
+
 # Contributing
 
 This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
@@ -10,4 +11,5 @@ If you find a bug or have an idea for improvement, please open an issue.
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).
+
 <!-- end: ozzy-labs/commons -->

--- a/dist/.github/copilot-instructions.md
+++ b/dist/.github/copilot-instructions.md
@@ -1,4 +1,5 @@
 <!-- begin: ozzy-labs/commons -->
+
 # GitHub Copilot Instructions
 
 共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
@@ -27,4 +28,5 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+
 <!-- end: ozzy-labs/commons -->

--- a/dist/CONTRIBUTING.md
+++ b/dist/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 <!-- begin: ozzy-labs/commons -->
+
 # Contributing
 
 This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
@@ -10,4 +11,5 @@ If you find a bug or have an idea for improvement, please open an issue.
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).
+
 <!-- end: ozzy-labs/commons -->


### PR DESCRIPTION
## Summary

- `dist/CONTRIBUTING.md` と `dist/.github/copilot-instructions.md` の `<!-- begin/end: ozzy-labs/commons -->` マーカー前後に空行を追加
- prettier を pre-commit / CI で走らせる consumer (例: tech-notes) が sync 後に format-fix なしでパスするようになる

Closes #103.

## Test plan

- [x] `pnpm run lint:md` で markdownlint 0 errors
- [x] `npx prettier --check` で標準設定パス
- [ ] tech-notes 側で次回 sync PR が prettier に引っかからないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)