### PR TITLE
feat(routines): distribute Claude Code Routines templates

### DIFF
--- a/.claude/routines/README.md
+++ b/.claude/routines/README.md
@@ -1,0 +1,102 @@
+# Claude Code Routines
+
+[Claude Code Routines](https://code.claude.com/docs/en/routines)（Anthropic クラウド側で動く非対話エージェント）の設定をリポジトリで管理するためのディレクトリ。
+
+## ⚠️ `.claude/skills/` とは別物
+
+| 項目         | `.claude/skills/`         | `.claude/routines/` (このディレクトリ)     |
+| ------------ | ------------------------- | ------------------------------------------ |
+| ロード       | Claude Code が auto-load  | **Anthropic クラウド側に手動コピー**       |
+| 実行場所     | ローカル CLI              | Anthropic クラウド VM                      |
+| 自動連携     | あり                      | **なし**（リポは正本のコピー先にすぎない） |
+| シークレット | `.env` から読める         | Web UI 側の secret として別管理            |
+
+このディレクトリのファイルを編集しても**自動では Web UI に反映されない**。必ず手動で同期する。
+
+## ディレクトリ構造
+
+```text
+.claude/routines/
+├── README.md              # このファイル
+├── _template/             # 新規 routine 作成のひな形
+│   ├── routine.yaml
+│   ├── prompt.md
+│   └── setup.sh
+└── <routine-name>/        # 1 routine = 1 ディレクトリ
+    ├── routine.yaml       # メタデータ・トリガー・権限
+    ├── prompt.md          # Web UI の Prompt 欄に貼り付ける本文
+    └── setup.sh           # Web UI の Setup script 欄に貼り付ける本文
+```
+
+## 運用ルール
+
+### 正本はリポ
+
+- Web UI で直接編集**しない**
+- 変更は必ずリポの PR → マージ → Web UI に手で反映、の順で行う
+- Anthropic 側に GET routine API がないため drift の機械検知は不可能。規約で守る
+
+### 新規追加
+
+1. `cp -r .claude/routines/_template .claude/routines/<new-name>`
+2. 3 ファイルを編集（`routine.yaml` / `prompt.md` / `setup.sh`）
+   - `routine.yaml` の `repositories:` を実際の `<owner>/<repo>` に置換
+   - `prompt.md` の `<owner>/<repo>` プレースホルダを置換
+   - `setup.sh` の **project-specific install** 領域に対象リポの依存解決コマンドを追加
+3. `status: draft` のまま PR 作成・マージ
+4. [claude.ai/code/routines](https://claude.ai/code/routines) で **New routine** → 各欄に `prompt.md` / `setup.sh` を貼り、`routine.yaml` の cron / 権限 / connectors を反映
+5. 表示された `routine_id` を `routine.yaml` に書き戻し、`status: active` に変更する小コミットを `main` に追加
+
+### 更新
+
+1. PR で 3 ファイルを更新 → マージ
+2. Web UI に手で反映
+
+### 削除
+
+1. Web UI で routine を削除
+2. `git rm -r .claude/routines/<name>/`
+
+### シークレットの取り扱い
+
+- 値は**絶対に commit しない**
+- `routine.yaml` の `environment.variables` には**名前だけ**書く
+- API trigger の fire token は password manager 等で別管理
+
+## ファイルの約束ごと
+
+### `setup.sh`
+
+- **ローカル実行可能な形に書く**: `bash .claude/routines/<name>/setup.sh` で動くこと
+- ターゲット環境は **Routines クラウド VM (Ubuntu)** 前提
+- `sudo apt-get` 等の Ubuntu 依存コマンドの利用は OK だが、ローカル検証は WSL/Linux で行う
+- mise を介して言語ツールチェーンを揃える前提（`.mise.toml` がリポルートにある想定）
+- 重複が増えたら `_lib/setup-common.sh` への切り出しを検討（**3 routine 目を作る前**を目安）
+
+### `prompt.md`
+
+- 完全自律実行を前提に self-contained に書く（`AskUserQuestion` は使わない）
+- ローカル MCP サーバー（`knowledge` / `context7` 等）はクラウド環境に存在しない前提で書く
+- `claude/*` ブランチで PR を立てる運用に揃える（main 直 push を要求しない）
+
+### `routine.yaml`
+
+- 必須: `name`, `description`, `status`, `repositories`, `model`, `triggers`
+- `status` は `active` または `draft` の 2 値（Web UI 未登録は `draft`）
+- `routine_id` は Web UI 登録後に書き戻す。空でよいのは `status: draft` のときだけ
+- `triggers` は配列（schedule / api / github を将来混在可能）
+
+## バリデーション（任意）
+
+`scripts/routines/validate.py` を用意すれば必須フィールド・cron 妥当性・`status: active` なら `routine_id` が空でないか等を検証できる。Lefthook の **pre-push** に組み込むのが推奨（pre-commit には入れない）。
+
+## opt-out
+
+特定リポでこのディレクトリを管理したくない場合は、`.commons/sync.yaml` の `pinned:` に `.claude/routines/` 配下のパスを追加して同期対象から外す。
+
+## 参考
+
+- [Automate work with routines](https://code.claude.com/docs/en/routines)
+- [Trigger a routine via API](https://platform.claude.com/docs/en/api/claude-code/routines-fire)
+- [Claude Code on the web（cloud environment）](https://code.claude.com/docs/en/claude-code-on-the-web)
+- knowledge MCP: `ai/agents/claude-code-routines`, `ai/practice/scheduled-tasks`

--- a/.claude/routines/_template/prompt.md
+++ b/.claude/routines/_template/prompt.md
@@ -1,0 +1,27 @@
+# Routine Prompt Template
+
+> このファイルの内容を Web UI の **Prompt** 欄にそのまま貼り付ける。
+> 完全自律実行が前提（`AskUserQuestion` は機能しない）。
+
+---
+
+You are running `ROUTINE_NAME` for the `<owner>/<repo>` repository. This is a fully autonomous run — there is no human to answer prompts.
+
+## Goal
+
+(このルーチンが達成すべきゴールを 1〜2 文で記述)
+
+## Steps
+
+1. ステップ 1
+2. ステップ 2
+3. ステップ 3
+
+## Hard constraints
+
+- Do NOT use `AskUserQuestion` — the run is autonomous.
+- Do NOT call MCP servers (`knowledge`, `context7`); they are not configured in the cloud environment.
+- Do NOT push to `main` directly. Always use a `claude/<scope>/...` branch.
+- Do NOT amend or force-push.
+- Do NOT modify files outside the scope of this routine.
+- Use Conventional Commits with the appropriate `type(scope):` prefix.

--- a/.claude/routines/_template/routine.yaml
+++ b/.claude/routines/_template/routine.yaml
@@ -1,0 +1,44 @@
+# Claude Code Routine のメタデータ。
+# このファイルは正本（source of truth）。Web UI で直接編集せず、変更は必ずここから行う。
+
+name: <routine-name>
+description: <一行サマリ>
+
+# active = Web UI に登録済みで稼働中
+# draft  = Web UI 未登録（PR レビュー段階など）
+status: draft
+
+# Web UI 登録後に発行される ID（trig_xxxx）。draft の間は空でよい。
+routine_id: ""
+
+repositories:
+  - <owner>/<repo>
+
+model: claude-sonnet-4-6
+
+# トリガーは配列。schedule / api / github を将来併用可能。
+triggers:
+  - type: scheduled
+    # 5 フィールドの cron 式（最小実行間隔は 1 時間）
+    cron: "0 23 * * *"
+    # Web UI ではローカル TZ 入力 → 内部で UTC 変換される。記録は UTC 統一。
+    timezone: UTC
+
+permissions:
+  # claude/* ブランチ以外への push を許可するか。デフォルト false。
+  unrestricted_branch_pushes: false
+
+# Web UI の Connectors で included にする MCP サーバー名のリスト。
+# ローカル stdio MCP（knowledge / context7 等）はクラウドに届かないため空のままが基本。
+connectors: []
+
+environment:
+  # 環境変数の名前のみ列挙する。値は絶対に書かない（Web UI 側の secret として登録）。
+  variables: []
+
+# 同ディレクトリ内のファイル参照。固定で OK。
+prompt_file: prompt.md
+setup_script: setup.sh
+
+notes: |
+  運用上のメモ・既知の注意点があればここに書く。

--- a/.claude/routines/_template/setup.sh
+++ b/.claude/routines/_template/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Routine Setup script template.
+#
+# このファイルの内容を Web UI の Setup script 欄にそのまま貼り付ける。
+# ローカル検証用に `bash .claude/routines/<name>/setup.sh` でも動く形に保つ。
+# ターゲット環境は Routines のクラウド VM (Ubuntu)。
+set -euo pipefail
+
+# 1. mise (polyglot toolchain manager) — installs from .mise.toml
+curl https://mise.run | sh
+export PATH="${HOME}/.local/bin:${PATH}"
+eval "$(mise activate bash)"
+
+# 2. 言語ツールチェーン一括インストール（Python / Node / その他）
+mise install
+
+# 3. gh CLI（PR 操作に使用。Routines のクラウド VM にプリインストールされていない）
+sudo apt-get update -qq
+sudo apt-get install -y -qq gh
+
+# 4. ── project-specific install ──────────────────────────────────
+#  以下は routine ごとに書き換える領域。新しい routine を作るときに
+#  `cp -r _template <name>/` した後で、対象 repo の依存解決コマンドを書く。
+#
+# 例:
+#   uv sync --frozen                # Python (uv)
+#   pnpm install --frozen-lockfile  # Node (pnpm)
+#   bundle install --jobs=4         # Ruby

--- a/dist/.claude/routines/README.md
+++ b/dist/.claude/routines/README.md
@@ -1,0 +1,102 @@
+# Claude Code Routines
+
+[Claude Code Routines](https://code.claude.com/docs/en/routines)（Anthropic クラウド側で動く非対話エージェント）の設定をリポジトリで管理するためのディレクトリ。
+
+## ⚠️ `.claude/skills/` とは別物
+
+| 項目         | `.claude/skills/`         | `.claude/routines/` (このディレクトリ)     |
+| ------------ | ------------------------- | ------------------------------------------ |
+| ロード       | Claude Code が auto-load  | **Anthropic クラウド側に手動コピー**       |
+| 実行場所     | ローカル CLI              | Anthropic クラウド VM                      |
+| 自動連携     | あり                      | **なし**（リポは正本のコピー先にすぎない） |
+| シークレット | `.env` から読める         | Web UI 側の secret として別管理            |
+
+このディレクトリのファイルを編集しても**自動では Web UI に反映されない**。必ず手動で同期する。
+
+## ディレクトリ構造
+
+```text
+.claude/routines/
+├── README.md              # このファイル
+├── _template/             # 新規 routine 作成のひな形
+│   ├── routine.yaml
+│   ├── prompt.md
+│   └── setup.sh
+└── <routine-name>/        # 1 routine = 1 ディレクトリ
+    ├── routine.yaml       # メタデータ・トリガー・権限
+    ├── prompt.md          # Web UI の Prompt 欄に貼り付ける本文
+    └── setup.sh           # Web UI の Setup script 欄に貼り付ける本文
+```
+
+## 運用ルール
+
+### 正本はリポ
+
+- Web UI で直接編集**しない**
+- 変更は必ずリポの PR → マージ → Web UI に手で反映、の順で行う
+- Anthropic 側に GET routine API がないため drift の機械検知は不可能。規約で守る
+
+### 新規追加
+
+1. `cp -r .claude/routines/_template .claude/routines/<new-name>`
+2. 3 ファイルを編集（`routine.yaml` / `prompt.md` / `setup.sh`）
+   - `routine.yaml` の `repositories:` を実際の `<owner>/<repo>` に置換
+   - `prompt.md` の `<owner>/<repo>` プレースホルダを置換
+   - `setup.sh` の **project-specific install** 領域に対象リポの依存解決コマンドを追加
+3. `status: draft` のまま PR 作成・マージ
+4. [claude.ai/code/routines](https://claude.ai/code/routines) で **New routine** → 各欄に `prompt.md` / `setup.sh` を貼り、`routine.yaml` の cron / 権限 / connectors を反映
+5. 表示された `routine_id` を `routine.yaml` に書き戻し、`status: active` に変更する小コミットを `main` に追加
+
+### 更新
+
+1. PR で 3 ファイルを更新 → マージ
+2. Web UI に手で反映
+
+### 削除
+
+1. Web UI で routine を削除
+2. `git rm -r .claude/routines/<name>/`
+
+### シークレットの取り扱い
+
+- 値は**絶対に commit しない**
+- `routine.yaml` の `environment.variables` には**名前だけ**書く
+- API trigger の fire token は password manager 等で別管理
+
+## ファイルの約束ごと
+
+### `setup.sh`
+
+- **ローカル実行可能な形に書く**: `bash .claude/routines/<name>/setup.sh` で動くこと
+- ターゲット環境は **Routines クラウド VM (Ubuntu)** 前提
+- `sudo apt-get` 等の Ubuntu 依存コマンドの利用は OK だが、ローカル検証は WSL/Linux で行う
+- mise を介して言語ツールチェーンを揃える前提（`.mise.toml` がリポルートにある想定）
+- 重複が増えたら `_lib/setup-common.sh` への切り出しを検討（**3 routine 目を作る前**を目安）
+
+### `prompt.md`
+
+- 完全自律実行を前提に self-contained に書く（`AskUserQuestion` は使わない）
+- ローカル MCP サーバー（`knowledge` / `context7` 等）はクラウド環境に存在しない前提で書く
+- `claude/*` ブランチで PR を立てる運用に揃える（main 直 push を要求しない）
+
+### `routine.yaml`
+
+- 必須: `name`, `description`, `status`, `repositories`, `model`, `triggers`
+- `status` は `active` または `draft` の 2 値（Web UI 未登録は `draft`）
+- `routine_id` は Web UI 登録後に書き戻す。空でよいのは `status: draft` のときだけ
+- `triggers` は配列（schedule / api / github を将来混在可能）
+
+## バリデーション（任意）
+
+`scripts/routines/validate.py` を用意すれば必須フィールド・cron 妥当性・`status: active` なら `routine_id` が空でないか等を検証できる。Lefthook の **pre-push** に組み込むのが推奨（pre-commit には入れない）。
+
+## opt-out
+
+特定リポでこのディレクトリを管理したくない場合は、`.commons/sync.yaml` の `pinned:` に `.claude/routines/` 配下のパスを追加して同期対象から外す。
+
+## 参考
+
+- [Automate work with routines](https://code.claude.com/docs/en/routines)
+- [Trigger a routine via API](https://platform.claude.com/docs/en/api/claude-code/routines-fire)
+- [Claude Code on the web（cloud environment）](https://code.claude.com/docs/en/claude-code-on-the-web)
+- knowledge MCP: `ai/agents/claude-code-routines`, `ai/practice/scheduled-tasks`

--- a/dist/.claude/routines/_template/prompt.md
+++ b/dist/.claude/routines/_template/prompt.md
@@ -1,0 +1,27 @@
+# Routine Prompt Template
+
+> このファイルの内容を Web UI の **Prompt** 欄にそのまま貼り付ける。
+> 完全自律実行が前提（`AskUserQuestion` は機能しない）。
+
+---
+
+You are running `ROUTINE_NAME` for the `<owner>/<repo>` repository. This is a fully autonomous run — there is no human to answer prompts.
+
+## Goal
+
+(このルーチンが達成すべきゴールを 1〜2 文で記述)
+
+## Steps
+
+1. ステップ 1
+2. ステップ 2
+3. ステップ 3
+
+## Hard constraints
+
+- Do NOT use `AskUserQuestion` — the run is autonomous.
+- Do NOT call MCP servers (`knowledge`, `context7`); they are not configured in the cloud environment.
+- Do NOT push to `main` directly. Always use a `claude/<scope>/...` branch.
+- Do NOT amend or force-push.
+- Do NOT modify files outside the scope of this routine.
+- Use Conventional Commits with the appropriate `type(scope):` prefix.

--- a/dist/.claude/routines/_template/routine.yaml
+++ b/dist/.claude/routines/_template/routine.yaml
@@ -1,0 +1,44 @@
+# Claude Code Routine のメタデータ。
+# このファイルは正本（source of truth）。Web UI で直接編集せず、変更は必ずここから行う。
+
+name: <routine-name>
+description: <一行サマリ>
+
+# active = Web UI に登録済みで稼働中
+# draft  = Web UI 未登録（PR レビュー段階など）
+status: draft
+
+# Web UI 登録後に発行される ID（trig_xxxx）。draft の間は空でよい。
+routine_id: ""
+
+repositories:
+  - <owner>/<repo>
+
+model: claude-sonnet-4-6
+
+# トリガーは配列。schedule / api / github を将来併用可能。
+triggers:
+  - type: scheduled
+    # 5 フィールドの cron 式（最小実行間隔は 1 時間）
+    cron: "0 23 * * *"
+    # Web UI ではローカル TZ 入力 → 内部で UTC 変換される。記録は UTC 統一。
+    timezone: UTC
+
+permissions:
+  # claude/* ブランチ以外への push を許可するか。デフォルト false。
+  unrestricted_branch_pushes: false
+
+# Web UI の Connectors で included にする MCP サーバー名のリスト。
+# ローカル stdio MCP（knowledge / context7 等）はクラウドに届かないため空のままが基本。
+connectors: []
+
+environment:
+  # 環境変数の名前のみ列挙する。値は絶対に書かない（Web UI 側の secret として登録）。
+  variables: []
+
+# 同ディレクトリ内のファイル参照。固定で OK。
+prompt_file: prompt.md
+setup_script: setup.sh
+
+notes: |
+  運用上のメモ・既知の注意点があればここに書く。

--- a/dist/.claude/routines/_template/setup.sh
+++ b/dist/.claude/routines/_template/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Routine Setup script template.
+#
+# このファイルの内容を Web UI の Setup script 欄にそのまま貼り付ける。
+# ローカル検証用に `bash .claude/routines/<name>/setup.sh` でも動く形に保つ。
+# ターゲット環境は Routines のクラウド VM (Ubuntu)。
+set -euo pipefail
+
+# 1. mise (polyglot toolchain manager) — installs from .mise.toml
+curl https://mise.run | sh
+export PATH="${HOME}/.local/bin:${PATH}"
+eval "$(mise activate bash)"
+
+# 2. 言語ツールチェーン一括インストール（Python / Node / その他）
+mise install
+
+# 3. gh CLI（PR 操作に使用。Routines のクラウド VM にプリインストールされていない）
+sudo apt-get update -qq
+sudo apt-get install -y -qq gh
+
+# 4. ── project-specific install ──────────────────────────────────
+#  以下は routine ごとに書き換える領域。新しい routine を作るときに
+#  `cp -r _template <name>/` した後で、対象 repo の依存解決コマンドを書く。
+#
+# 例:
+#   uv sync --frozen                # Python (uv)
+#   pnpm install --frozen-lockfile  # Node (pnpm)
+#   bundle install --jobs=4         # Ruby

--- a/sync.sh
+++ b/sync.sh
@@ -137,6 +137,8 @@ is_surgical() {
   *.json | *.yaml | *.yml)
     # Exclude certain files that should be handled as a whole
     [[ "${file}" == "lefthook.yaml" ]] && return 1
+    # _template/ files are scaffolds — full copy preserves comments and layout
+    [[ "${file}" == */_template/* ]] && return 1
     return 0
     ;;
   *)

--- a/tests/surgical-merge.bats
+++ b/tests/surgical-merge.bats
@@ -117,6 +117,42 @@ EOF
   [ "$(yq '.rules.indentation.spaces' "${TARGET_DIR}/.yamllint.yaml")" = "4" ]
 }
 
+@test "_template/ YAML files are full-copied (not surgical-merged) to preserve comments" {
+  # _template/ files are scaffolds with educational comments.
+  # Surgical merge with yq strips comments and reorders keys, which would
+  # cumulatively damage the scaffold across syncs. They must be full-copied.
+  mkdir -p "${SRC_DIR}/dist/.claude/routines/_template"
+  cat <<'EOF' > "${SRC_DIR}/dist/.claude/routines/_template/routine.yaml"
+# Comment that must survive the sync
+name: <routine-name>
+
+# Section header comment
+status: draft
+EOF
+  git -C "${SRC_DIR}" add .
+  git -C "${SRC_DIR}" commit -q -m "add routines template"
+
+  # Create existing target with different content (to trigger 'changed' path)
+  mkdir -p "${TARGET_DIR}/.claude/routines/_template"
+  cat <<'EOF' > "${TARGET_DIR}/.claude/routines/_template/routine.yaml"
+name: <old-name>
+status: active
+EOF
+  git -C "${TARGET_DIR}" add .
+  git -C "${TARGET_DIR}" commit -q -m "old template"
+
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+
+  # Should be reported as copy, not merge
+  [[ "$output" == *"copy: .claude/routines/_template/routine.yaml"* ]]
+  [[ "$output" != *"merge: .claude/routines/_template/routine.yaml"* ]]
+
+  # Comments must be preserved (yq surgical merge would have stripped them)
+  grep -q "Comment that must survive the sync" "${TARGET_DIR}/.claude/routines/_template/routine.yaml"
+  grep -q "Section header comment" "${TARGET_DIR}/.claude/routines/_template/routine.yaml"
+}
+
 @test "interactive mode offers 'm' for surgical files and performs merge" {
   # Create a surgical file in dist
   cat <<EOF > "${SRC_DIR}/dist/biome.json"


### PR DESCRIPTION
## Summary

- `dist/.claude/routines/` を新設し、Claude Code Routines のひな形を全 consumer repo に sync 経由で配布
- README + `_template/` (`routine.yaml` / `prompt.md` / `setup.sh`) で 1 routine = 3 ファイルの構成を共通化
- `setup.sh` は mise を polyglot toolchain manager として前提（言語非依存）
- `sync.sh` の `is_surgical()` を 1 行修正し、`_template/` 配下を full-copy 扱いにする
  - yq の surgical merge は scaffold YAML のコメント / 空行 / キー順序を破壊するため
- `tests/surgical-merge.bats` に regression test を追加

Closes #107

## 設計の要点

- **正本はリポ**: Web UI で直接編集しない。Anthropic 側に GET routine API がない
- **`<owner>/<repo>` placeholder**: `routine.yaml` の `repositories:` と `prompt.md` の repo 名は新規作成時に置換
- **mise 前提**: ozzy-labs 内の他 commons 配布物（lefthook-base.yaml 等）と整合
- **シークレット**: `environment.variables` は名前のみ。値は Web UI 側 secret として別管理

## Test plan

- [x] `tests/surgical-merge.bats` 全 4 テスト通過（新規 1 件含む）
- [x] `bats tests/` 全 95 テスト通過
- [x] `bash sync.sh --dry-run /tmp/test-target` で `_template/` 配下が `new:` として 4 件検出
- [x] `bash sync.sh --dry-run ~/github/ozzy-labs/writing-studio` で `changed:` として 4 件検出（既存版を上書き）
- [x] `shellcheck` / `yamllint` / `markdownlint-cli2` / `gitleaks` / `trivy` 全通過
- [x] `bash check.sh` で self-sync PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)