### PR TITLE
ci: bump checkout to v6.0.2 and mise-action to v4.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
       # See handbook#84 / commons#73.
       MISE_DISABLE_TOOLS: trivy
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           install: true
           cache: true


### PR DESCRIPTION
## Summary

Closes #113. CI workflow を下流リポと同一の最新 SHA に揃える。

- `actions/checkout` v4 → **v6.0.2** (`de0fac2`)
- `jdx/mise-action` v2 → **v4.0.1** (`1648a78`) — 2 メジャー遅れ解消

## Test plan

- [x] yamlfmt / actionlint クリーン
- [ ] PR の ci ワークフローが新 SHA で成功すること