### PR TITLE
fix(lefthook): wrap commands with mise exec to fix mise-only env failures

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Runtime & package managers
 node = "24"
-"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+"npm:pnpm" = "10" # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
 uv = "0.11.10"
 
 # Linters & formatters

--- a/dist/.mise.toml
+++ b/dist/.mise.toml
@@ -1,7 +1,7 @@
 [tools]
 # Runtime & package managers
 node = "24"
-"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+"npm:pnpm" = "10" # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
 uv = "0.11.10"
 
 # Linters & formatters

--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -18,8 +18,9 @@ commit-msg:
       # NODE_PATH lets commitlint resolve @commitlint/config-conventional when
       # both packages are installed via mise's npm: backend, which places each
       # package in its own isolated install dir.
-      run: NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" mise exec -- commitlint
-        --edit {1}
+      run: |
+        NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" \
+          mise exec -- commitlint --edit {1}
 
 pre-commit:
   parallel: true

--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -4,31 +4,43 @@
 #   extends:
 #     - lefthook-base.yaml
 #
-# Then add repo-specific commands (biome, taplo, ruff, etc.)
+# Then add repo-specific commands (biome, ruff, etc.)
+#
+# All commands run via `mise exec --` so hooks succeed even when the calling
+# shell hasn't run `mise activate` (e.g. `bash -c 'git commit ...'`, IDE
+# integrations). See ozzy-labs/commons#117.
 
 glob_matcher: doublestar
 
 commit-msg:
   commands:
     commitlint:
-      run: commitlint --edit {1}
+      # NODE_PATH lets commitlint resolve @commitlint/config-conventional when
+      # both packages are installed via mise's npm: backend, which places each
+      # package in its own isolated install dir.
+      run: NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" mise exec -- commitlint
+        --edit {1}
 
 pre-commit:
   parallel: true
   commands:
     shell:
       glob: "**/*.sh"
-      run: shfmt -w {staged_files} && shellcheck {staged_files}
+      run: mise exec -- shfmt -w {staged_files} && mise exec -- shellcheck {staged_files}
       stage_fixed: true
     markdownlint:
       glob: "**/*.md"
-      run: markdownlint-cli2 --fix {staged_files}
+      run: mise exec -- markdownlint-cli2 --fix {staged_files}
       stage_fixed: true
     yaml:
       glob: "**/*.{yaml,yml}"
-      run: yamlfmt {staged_files} && yamllint -c .yamllint.yaml {staged_files}
+      run: mise exec -- yamlfmt {staged_files} && mise exec -- yamllint -c .yamllint.yaml {staged_files}
+      stage_fixed: true
+    taplo:
+      glob: "**/*.toml"
+      run: mise exec -- taplo format {staged_files}
       stage_fixed: true
     gitleaks:
-      run: gitleaks protect --staged --no-banner
+      run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -18,8 +18,9 @@ commit-msg:
       # NODE_PATH lets commitlint resolve @commitlint/config-conventional when
       # both packages are installed via mise's npm: backend, which places each
       # package in its own isolated install dir.
-      run: NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" mise exec -- commitlint
-        --edit {1}
+      run: |
+        NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" \
+          mise exec -- commitlint --edit {1}
 
 pre-commit:
   parallel: true

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -4,31 +4,43 @@
 #   extends:
 #     - lefthook-base.yaml
 #
-# Then add repo-specific commands (biome, taplo, ruff, etc.)
+# Then add repo-specific commands (biome, ruff, etc.)
+#
+# All commands run via `mise exec --` so hooks succeed even when the calling
+# shell hasn't run `mise activate` (e.g. `bash -c 'git commit ...'`, IDE
+# integrations). See ozzy-labs/commons#117.
 
 glob_matcher: doublestar
 
 commit-msg:
   commands:
     commitlint:
-      run: commitlint --edit {1}
+      # NODE_PATH lets commitlint resolve @commitlint/config-conventional when
+      # both packages are installed via mise's npm: backend, which places each
+      # package in its own isolated install dir.
+      run: NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" mise exec -- commitlint
+        --edit {1}
 
 pre-commit:
   parallel: true
   commands:
     shell:
       glob: "**/*.sh"
-      run: shfmt -w {staged_files} && shellcheck {staged_files}
+      run: mise exec -- shfmt -w {staged_files} && mise exec -- shellcheck {staged_files}
       stage_fixed: true
     markdownlint:
       glob: "**/*.md"
-      run: markdownlint-cli2 --fix {staged_files}
+      run: mise exec -- markdownlint-cli2 --fix {staged_files}
       stage_fixed: true
     yaml:
       glob: "**/*.{yaml,yml}"
-      run: yamlfmt {staged_files} && yamllint -c .yamllint.yaml {staged_files}
+      run: mise exec -- yamlfmt {staged_files} && mise exec -- yamllint -c .yamllint.yaml {staged_files}
+      stage_fixed: true
+    taplo:
+      glob: "**/*.toml"
+      run: mise exec -- taplo format {staged_files}
       stage_fixed: true
     gitleaks:
-      run: gitleaks protect --staged --no-banner
+      run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .


### PR DESCRIPTION
## Summary

- `lefthook-base.yaml` の全コマンドを `mise exec --` 経由で実行するように変更
- `taplo` を `lefthook-base.yaml` に追加（SSOT 化）
- `commitlint` には `NODE_PATH=$(mise where npm:@commitlint/config-conventional)/lib/node_modules` を付与し、mise の npm: backend が別ディレクトリに展開する sibling パッケージを resolve できるようにした

## Why

`mise activate` を有効にしていないシェル（`bash -c '...'`、IDE 統合経由など）から hook が走ると、bare `commitlint` / `taplo` などは PATH に存在せず失敗していた。`mise exec --` で囲むことで mise.toml に宣言された tool の PATH を確実に通す。`commitlint` だけは `mise exec --` でも sibling resolve が解決しないため `NODE_PATH` を補足。

## Test plan

- [x] `env -i HOME=$HOME PATH=/usr/bin:/bin:~/.local/bin bash -c 'mise exec -- lefthook run commit-msg <msg-file>'` で commitlint が PASS
- [x] 同条件で `lefthook run pre-commit --command taplo --all-files --force` が PASS
- [x] 既存の bats テスト 94 件が PASS
- [x] yamllint / yamlfmt / taplo format チェック PASS

## Out of scope

- 影響 4 リポ（create-agentic-app / create-agentic-aws / knowledge-mcp-server / ozzylabs.com）の `lefthook.yaml` 直下の重複 taplo 定義削除は別 PR で対応する

Closes #117