### PR TITLE
fix(sync): full-copy lefthook-base.yaml instead of surgical merge

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -137,6 +137,10 @@ is_surgical() {
   *.json | *.yaml | *.yml)
     # Exclude certain files that should be handled as a whole
     [[ "${file}" == "lefthook.yaml" ]] && return 1
+    # lefthook-base.yaml is a shared base; consumers extend it via lefthook.yaml
+    # and never add keys to it. yq surgical merge would compound free-floating
+    # header comments and reorder appended commands across syncs.
+    [[ "${file}" == "lefthook-base.yaml" ]] && return 1
     # _template scaffolds — full copy preserves comments and layout.
     # Matches both legacy directory form (`_template/<file>`) and current
     # single-file form (`_template.yaml`).

--- a/tests/surgical-merge.bats
+++ b/tests/surgical-merge.bats
@@ -153,6 +153,61 @@ EOF
   grep -q "Section header comment" "${TARGET_DIR}/.claude/routines/_template.yaml"
 }
 
+@test "lefthook-base.yaml is full-copied (not surgical-merged) to avoid header/key drift" {
+  # lefthook-base.yaml is a shared base — consumers extend via lefthook.yaml and
+  # never add keys to it. yq surgical merge would compound free-floating header
+  # comments across syncs and append new keys at the bottom, drifting from dist.
+  cat <<'EOF' > "${SRC_DIR}/dist/lefthook-base.yaml"
+# Header comment v2
+commit-msg:
+  commands:
+    commitlint:
+      run: new-commitlint --edit {1}
+pre-commit:
+  commands:
+    shell:
+      run: new-shfmt
+    taplo:
+      run: new-taplo
+EOF
+  git -C "${SRC_DIR}" add .
+  git -C "${SRC_DIR}" commit -q -m "update lefthook-base"
+
+  # Existing target with old header and only `shell` (no taplo)
+  cat <<'EOF' > "${TARGET_DIR}/lefthook-base.yaml"
+# Header comment v1
+commit-msg:
+  commands:
+    commitlint:
+      run: old-commitlint --edit {1}
+pre-commit:
+  commands:
+    shell:
+      run: old-shfmt
+EOF
+  git -C "${TARGET_DIR}" add lefthook-base.yaml
+  git -C "${TARGET_DIR}" commit -q -m "old lefthook-base"
+
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+
+  # Should be reported as copy, not merge
+  [[ "$output" == *"copy: lefthook-base.yaml"* ]]
+  [[ "$output" != *"merge: lefthook-base.yaml"* ]]
+
+  # Old header must NOT remain (full copy replaces it)
+  ! grep -q "Header comment v1" "${TARGET_DIR}/lefthook-base.yaml"
+  grep -q "Header comment v2" "${TARGET_DIR}/lefthook-base.yaml"
+
+  # Header must appear exactly once (no compounding)
+  [ "$(grep -c "^# Header comment" "${TARGET_DIR}/lefthook-base.yaml")" = "1" ]
+
+  # New content from dist must win
+  [ "$(yq '.commit-msg.commands.commitlint.run' "${TARGET_DIR}/lefthook-base.yaml")" = "new-commitlint --edit {1}" ]
+  [ "$(yq '.pre-commit.commands.shell.run' "${TARGET_DIR}/lefthook-base.yaml")" = "new-shfmt" ]
+  [ "$(yq '.pre-commit.commands.taplo.run' "${TARGET_DIR}/lefthook-base.yaml")" = "new-taplo" ]
+}
+
 @test "interactive mode offers 'm' for surgical files and performs merge" {
   # Create a surgical file in dist
   cat <<EOF > "${SRC_DIR}/dist/biome.json"


### PR DESCRIPTION
## Summary

- `sync.sh` の `is_surgical()` で `lefthook-base.yaml` を除外し full-copy 化
- 退化テストを `tests/surgical-merge.bats` に追加（`_template.yaml` 用テストと同形）

## Why

`lefthook-base.yaml` は consumer が key を追加しない共通ベース（consumer は `lefthook.yaml` の `extends:` で利用）。`yq eval-all 'select(0) * select(1)'` でマージすると:

- free-floating header コメントが連結されて毎 sync ごとに重複・累積
- 新規 map key（例: `taplo`）が末尾に追加されて dist の並びと乖離

#118 でヘッダーコメントブロックと `taplo` を追加した結果、12 リポ中 11 リポに drift が発生したのを契機に修正。

設計上は `lefthook.yaml` と同じ扱いが正しい（既に full-copy 除外）。`tests/surgical-merge.bats:120` の `_template.yaml` テストでも「surgical merge は scaffold には不適」と認識済みで、同じ判定を適用する。

## Test plan

- [x] 新テスト: ヘッダー重複なし・新規 key（`taplo`）が反映されること・"copy" として報告されること を検証
- [x] 既存 95 件含めて全 PASS

## Follow-up

main マージ後、影響リポ（gh-tasks / road を除く 10 リポ）で `Sync commons` workflow を `gh workflow run` で起動し、drift 解消 PR を一括で立ち上げる。