### PR TITLE
docs(lefthook): document the skip+replacement override pattern

### DIFF
--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -9,6 +9,22 @@
 # All commands run via `mise exec --` so hooks succeed even when the calling
 # shell hasn't run `mise activate` (e.g. `bash -c 'git commit ...'`, IDE
 # integrations). See ozzy-labs/commons#117.
+#
+# === Overriding inherited commands ===
+# lefthook 2.1.6's extends merge is base-wins: a same-key command in your
+# lefthook.yaml is silently ignored. To replace a base command, mark it
+# `skip: true` locally and add a replacement under a different key:
+#
+#   pre-commit:
+#     commands:
+#       shell:
+#         run: "true"   # stub — `lefthook validate` requires a string
+#         skip: true    # base's run still wins via merge but skip blocks it
+#       shell-local:
+#         glob: "**/*.sh"
+#         run: <your replacement command>
+#
+# See ozzy-labs/bootstrap#130 for a working example.
 
 glob_matcher: doublestar
 

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -9,6 +9,22 @@
 # All commands run via `mise exec --` so hooks succeed even when the calling
 # shell hasn't run `mise activate` (e.g. `bash -c 'git commit ...'`, IDE
 # integrations). See ozzy-labs/commons#117.
+#
+# === Overriding inherited commands ===
+# lefthook 2.1.6's extends merge is base-wins: a same-key command in your
+# lefthook.yaml is silently ignored. To replace a base command, mark it
+# `skip: true` locally and add a replacement under a different key:
+#
+#   pre-commit:
+#     commands:
+#       shell:
+#         run: "true"   # stub — `lefthook validate` requires a string
+#         skip: true    # base's run still wins via merge but skip blocks it
+#       shell-local:
+#         glob: "**/*.sh"
+#         run: <your replacement command>
+#
+# See ozzy-labs/bootstrap#130 for a working example.
 
 glob_matcher: doublestar
 


### PR DESCRIPTION
## Summary

`lefthook-base.yaml` のヘッダーコメントに **base コマンドを override する手順** を 16 行ほど追記。

## Why

ozzy-labs/bootstrap#130 で発覚した非自明な仕様:

- lefthook 2.1.6 の extends merge は **base が勝つ** → consumer の `lefthook.yaml` で同名コマンドを書いても silent に無視される
- override には `skip: true` + 別名 replacement が必要
- さらに `lefthook validate` が `run` を string 必須として検証するため `run: "true"` のスタブ併記が必要

これらは個別に試行錯誤しないと気付かない。`lefthook-base.yaml` のヘッダーに置けば、将来 override しようとした開発者が **extends を書いた瞬間に目に入る**。

## Propagation

main マージ後、各 consumer リポで `Sync commons` workflow を起動し dist/lefthook-base.yaml の更新を一括展開する。