### PR TITLE
chore: update lefthook comment ref to agentic-bootstrap

### DIFF
--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -24,7 +24,7 @@
 #         glob: "**/*.sh"
 #         run: <your replacement command>
 #
-# See ozzy-labs/bootstrap#130 for a working example.
+# See ozzy-labs/agentic-bootstrap#130 for a working example.
 
 glob_matcher: doublestar
 


### PR DESCRIPTION
## Summary

`lefthook-base.yaml` L27 のコメント参照を `ozzy-labs/bootstrap#130` → `ozzy-labs/agentic-bootstrap#130` に更新。

## Why

repo rename（`ozzy-labs/bootstrap` → `ozzy-labs/agentic-bootstrap`、ozzy-labs/agentic-bootstrap#132）後のブランド整合。GitHub redirect で機能上は不要だが、本ファイルが各 consumer に sync される SSOT のため commons から更新する必要がある。

## Test plan

- [x] yamlfmt + yamllint 通過
- [x] commitlint 通過

Refs: ozzy-labs/handbook#107