### PR TITLE
chore: sync dist/lefthook-base comment ref to agentic-bootstrap

### DIFF
--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -24,7 +24,7 @@
 #         glob: "**/*.sh"
 #         run: <your replacement command>
 #
-# See ozzy-labs/bootstrap#130 for a working example.
+# See ozzy-labs/agentic-bootstrap#130 for a working example.
 
 glob_matcher: doublestar
 


### PR DESCRIPTION
## Summary

`dist/lefthook-base.yaml` L27 のコメント参照を `ozzy-labs/bootstrap#130` → `ozzy-labs/agentic-bootstrap#130` に更新。

## Why

PR #121 は root の `lefthook-base.yaml` のみ更新したが、consumer に sync 配信されるのは `dist/lefthook-base.yaml` 側（`sync.sh` の `DIST_DIR=${SCRIPT_DIR}/dist`）。本 PR で配信源を整合させる。

## Test plan

- [x] yamlfmt + yamllint 通過
- [x] commitlint 通過

Refs: ozzy-labs/handbook#107