### PR TITLE
feat(workflows): skip branch-name check for claude/ branches

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -59,6 +59,15 @@ jobs:
               return;
             }
 
+            // Claude Code's GitHub app creates PRs from branches like
+            // `claude/<slug>-<id>`. The naming is bot-controlled and does
+            // not match the type/description convention; skip the check
+            // for those PRs the same way Dependabot is exempted.
+            if (branch.startsWith('claude/')) {
+              core.info(`Branch is managed by Claude Code (${branch}), skipping check`);
+              return;
+            }
+
             if (!pattern.test(branch)) {
               core.setFailed(
                 `Branch name does not follow naming convention.\n\n` +


### PR DESCRIPTION
## Summary

`pr-check.yaml` の Branch Name Check に `claude/` skip rule を追加。Claude Code の GitHub app が作る PR ブランチは `claude/<slug>-<id>` 形式で、現行の `<type>/<description>` 規則に match しないため、Claude bot 経由の全 PR で fail していた。

## Reproduction

`ozzy-labs/gh-tasks` リポで実機確認:

| Run ID | PR | Branch | Status |
| --- | --- | --- | --- |
| 25554182978 | claude/fix-agents-md-template | claude/fix-agents-md-template-KvlSs | Fail Branch Name Check |
| 25553941582 | claude/fix-broken-reference | claude/fix-broken-reference-fOy1Q | Fail Branch Name Check |
| 25553826780 | claude/fix-broken-reference | claude/fix-broken-reference-fOy1Q | Fail Branch Name Check |

すべて 2026-05-08 単日内、同根の失敗。

## Change

既存の dependabot / release-please skip と完全同型で claude/ を追加。PR Title check には変更なし。

## Test plan

- [x] yamllint / actionlint 0 errors
- [ ] sync 適用後、ozzy-labs/gh-tasks の次回 Claude bot PR で Branch Name Check が pass することを確認

## Refs

- Detection: ozzy-labs/gh-tasks の CI 失敗ログ調査 (2026-05-09)
- 同型例: dependabot[bot] / release-please-- の既存 skip