### PR TITLE
feat(sync-skills): distribute .claude/agents/ via collect_flat_dir_ops

### DIFF
--- a/sync-skills.sh
+++ b/sync-skills.sh
@@ -272,6 +272,19 @@ collect_skill_dir_ops() {
   done
 }
 
+# Flat copy: iterate *.md files directly under src_dir (no recursion).
+# Used for .claude/agents/, where each file is a standalone agent definition.
+collect_flat_dir_ops() {
+  local src_dir="$1" dst_dir="$2"
+  local file rel_in_dir dst_file rel
+  while IFS= read -r file; do
+    rel_in_dir="${file#"${src_dir}/"}"
+    dst_file="${dst_dir}/${rel_in_dir}"
+    rel="${dst_file#"${TARGET_DIR}/"}"
+    add_file_op "${file}" "${dst_file}" "${rel}"
+  done < <(find "${src_dir}" -maxdepth 1 -type f -name '*.md' | sort)
+}
+
 # --- Plan operations per adapter ---
 
 for a in "${ADAPTERS[@]}"; do
@@ -283,6 +296,14 @@ for a in "${ADAPTERS[@]}"; do
       exit 1
     fi
     collect_skill_dir_ops "${src_root}" "${TARGET_DIR}/.claude/skills"
+
+    # Optional agent distribution (ADR-0026). No-op if skills dist
+    # predates the convention. perspectives/ files live under skill dirs
+    # and are already carried by collect_skill_dir_ops above.
+    src_agents="${SKILLS_DIST}/claude-code/.claude/agents"
+    if [[ -d "${src_agents}" ]]; then
+      collect_flat_dir_ops "${src_agents}" "${TARGET_DIR}/.claude/agents"
+    fi
     ;;
   codex-cli)
     src_root="${SKILLS_DIST}/codex-cli/.agents/skills"

--- a/tests/sync-skills.bats
+++ b/tests/sync-skills.bats
@@ -456,3 +456,96 @@ EOF
   grep -q "<!-- begin: @ozzylabs/skills -->" "${TARGET_DIR}/AGENTS.md"
   grep -q "commit. — codex" "${TARGET_DIR}/AGENTS.md"
 }
+
+# --- ADR-0026: agents distribution (.claude/agents/) ---
+
+@test "claude-code adapter copies .claude/agents/ when present in skills dist" {
+  mkdir -p "${SKILLS_DIST}/claude-code/.claude/agents"
+  echo "code-reviewer agent" >"${SKILLS_DIST}/claude-code/.claude/agents/code-reviewer.md"
+
+  write_metadata "skills_adapters:
+  - claude-code"
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ -f "${TARGET_DIR}/.claude/agents/code-reviewer.md" ]
+  [ "$(cat "${TARGET_DIR}/.claude/agents/code-reviewer.md")" = "code-reviewer agent" ]
+  # Skills still copied (regression check)
+  [ -f "${TARGET_DIR}/.claude/skills/commit/SKILL.md" ]
+}
+
+@test "claude-code adapter is no-op for agents when .claude/agents/ absent in dist" {
+  # Default fixture has no .claude/agents/ directory in dist
+  write_metadata "skills_adapters:
+  - claude-code"
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ ! -d "${TARGET_DIR}/.claude/agents" ]
+  # Skills baseline still works
+  [ -f "${TARGET_DIR}/.claude/skills/commit/SKILL.md" ]
+}
+
+@test "agent file pin (file path) preserves consumer's local agent" {
+  mkdir -p "${SKILLS_DIST}/claude-code/.claude/agents"
+  echo "upstream agent" >"${SKILLS_DIST}/claude-code/.claude/agents/code-reviewer.md"
+
+  write_metadata "skills_adapters:
+  - claude-code
+pinned:
+  - .claude/agents/code-reviewer.md"
+
+  mkdir -p "${TARGET_DIR}/.claude/agents"
+  echo "my custom agent" >"${TARGET_DIR}/.claude/agents/code-reviewer.md"
+
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${TARGET_DIR}/.claude/agents/code-reviewer.md")" = "my custom agent" ]
+  [[ "$output" == *"pinned:"*".claude/agents/code-reviewer.md"* ]]
+}
+
+@test "agent directory pin (trailing slash) skips every agent" {
+  mkdir -p "${SKILLS_DIST}/claude-code/.claude/agents"
+  echo "upstream A" >"${SKILLS_DIST}/claude-code/.claude/agents/agent-a.md"
+  echo "upstream B" >"${SKILLS_DIST}/claude-code/.claude/agents/agent-b.md"
+
+  write_metadata "skills_adapters:
+  - claude-code
+pinned:
+  - .claude/agents/"
+
+  mkdir -p "${TARGET_DIR}/.claude/agents"
+  echo "my A" >"${TARGET_DIR}/.claude/agents/agent-a.md"
+
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ "$(cat "${TARGET_DIR}/.claude/agents/agent-a.md")" = "my A" ]
+  [ ! -f "${TARGET_DIR}/.claude/agents/agent-b.md" ]
+  # Skills are unaffected by agent dir pin
+  [ -f "${TARGET_DIR}/.claude/skills/commit/SKILL.md" ]
+}
+
+@test "--check detects out-of-sync agent files" {
+  mkdir -p "${SKILLS_DIST}/claude-code/.claude/agents"
+  echo "code-reviewer agent" >"${SKILLS_DIST}/claude-code/.claude/agents/code-reviewer.md"
+
+  write_metadata "skills_adapters:
+  - claude-code"
+  run "${SCRIPT}" --check "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"out of sync"* ]]
+  [[ "$output" == *".claude/agents/code-reviewer.md"* ]]
+}
+
+@test "non-md files under .claude/agents/ are not copied" {
+  mkdir -p "${SKILLS_DIST}/claude-code/.claude/agents"
+  echo "agent" >"${SKILLS_DIST}/claude-code/.claude/agents/code-reviewer.md"
+  echo "ignore" >"${SKILLS_DIST}/claude-code/.claude/agents/README"
+  echo "{}" >"${SKILLS_DIST}/claude-code/.claude/agents/config.json"
+
+  write_metadata "skills_adapters:
+  - claude-code"
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [ -f "${TARGET_DIR}/.claude/agents/code-reviewer.md" ]
+  [ ! -f "${TARGET_DIR}/.claude/agents/README" ]
+  [ ! -f "${TARGET_DIR}/.claude/agents/config.json" ]
+}


### PR DESCRIPTION
## Summary

ADR-0026 の実装。`sync-skills.sh` の `claude-code` 分岐に `.claude/agents/` の配信を追加し、`code-reviewer` 等の Claude Code agent ファイルを skills repo から consumer リポへ自動同期できるようにする。

- `collect_flat_dir_ops` ヘルパーを新規追加（指定ディレクトリ直下の `*.md` を flat にコピー）
- `claude-code` 分岐に `.claude/agents/` の opt-in 同期を追加（skills dist に agents ディレクトリが無い場合は no-op で後方互換）
- `perspectives/` は `src/skills/review/` 配下にあるため既存の `collect_skill_dir_ops` で運搬される（コード変更不要）
- bats テスト 6 件追加

## Test plan

- [x] `bats tests/sync-skills.bats` で 36 件 pass（既存 30 + 新規 6）
- [x] `pnpm run lint:shell`（shellcheck + shfmt）pass
- [x] lefthook pre-commit フック（trivy, gitleaks, shell, commitlint）pass
- [ ] consumer リポでの実動作確認は skills 側 (ozzy-labs/skills#59) で `code-reviewer` agent が dist に出力されてから

## References

- Closes #124
- ADR: ozzy-labs/handbook#110 (ADR-0026)
- Pair issue: ozzy-labs/skills#59 (ADR-0025 review redesign)