### PR TITLE
feat(templates): add @ozzylabs/skills marker block to AGENTS.md

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -124,7 +124,7 @@ Consumer の sync workflow が `skills_commit:` の SHA で `ozzy-labs/skills` �
 /path/to/commons/sync-skills.sh --check /path/to/skills/dist /path/to/target-repo
 ```
 
-Snippet 対象（`AGENTS.md` / `.github/copilot-instructions.md`）は対象ファイルにマーカーブロックが既に存在している必要がある。`<!-- begin: @ozzylabs/skills -->` と `<!-- end: @ozzylabs/skills -->` の間だけが置換され、その他のセクションは保持される。メタデータファイルの `pinned:` リストにパスを追加する（ディレクトリ全体は末尾に `/` を付ける）と、全 adapter で当該パスをスキップする。`.claude/skills/` や `.agents/skills/` 配下に consumer 固有のスキルディレクトリを置いても削除されない。
+Snippet 対象（`AGENTS.md` / `.github/copilot-instructions.md`）は対象ファイルにマーカーブロックが既に存在している必要がある。`<!-- begin: @ozzylabs/skills -->` と `<!-- end: @ozzylabs/skills -->` の間だけが置換され、その他のセクションは保持される。`templates/AGENTS.md` には marker block が事前に組み込まれており、template から scaffold した新規リポは codex-cli / gemini-cli adapter の opt-in 時に手作業の編集なしで対応できる。既存リポについては `commons check` が AGENTS.md の marker 不在を warning で報告するため、opt-in 前に retrofit できる。メタデータファイルの `pinned:` リストにパスを追加する（ディレクトリ全体は末尾に `/` を付ける）と、全 adapter で当該パスをスキップする。`.claude/skills/` や `.agents/skills/` 配下に consumer 固有のスキルディレクトリを置いても削除されない。
 
 ### リポジトリ初期設定
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ The consumer's sync workflow clones `ozzy-labs/skills` at `skills_commit:` and r
 /path/to/commons/sync-skills.sh --check /path/to/skills/dist /path/to/target-repo
 ```
 
-Snippet targets (`AGENTS.md`, `.github/copilot-instructions.md`) must already contain the marker block — only the content between `<!-- begin: @ozzylabs/skills -->` and `<!-- end: @ozzylabs/skills -->` is replaced. Pinning a path in the metadata file's `pinned:` list (with a trailing `/` for whole directories) skips it across all adapters. Consumer-only skill directories under `.claude/skills/` or `.agents/skills/` are preserved.
+Snippet targets (`AGENTS.md`, `.github/copilot-instructions.md`) must already contain the marker block — only the content between `<!-- begin: @ozzylabs/skills -->` and `<!-- end: @ozzylabs/skills -->` is replaced. `templates/AGENTS.md` ships with the marker block pre-installed, so new repos scaffolded from the template are ready for codex-cli / gemini-cli adapter opt-in without manual edits. `commons check` warns when the marker is missing from `AGENTS.md` so existing repos can be retrofitted before opt-in. Pinning a path in the metadata file's `pinned:` list (with a trailing `/` for whole directories) skips it across all adapters. Consumer-only skill directories under `.claude/skills/` or `.agents/skills/` are preserved.
 
 ### Repository setup
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -44,6 +44,12 @@ pnpm run build             # プロダクションビルド
 
 言語・コミット・ブランチ・PR のルールは README.md を参照すること。
 
+## Available Skills
+
+<!-- begin: @ozzylabs/skills -->
+<!-- このブロックは sync-skills.sh が opt-in 後に自動管理する。opt-in していない場合は空のままで問題ない。 -->
+<!-- end: @ozzylabs/skills -->
+
 ## Adapter Files
 
 | Agent          | Configuration                         |


### PR DESCRIPTION
## Summary

- `templates/AGENTS.md` に `@ozzylabs/skills` の marker block を事前組み込みし、template から scaffold した新規リポが codex-cli / gemini-cli adapter を opt-in する際に手作業の marker 追加が不要になるようにした。
- README.md / README.ja.md の skills sync セクションに、template に marker が同梱されている旨と、既存リポは `commons check` の warning で retrofit が誘導される旨を追記した。
- `commons check` の AGENTS.md marker 検査は既存（[check.sh:42-46](https://github.com/ozzy-labs/commons/blob/main/check.sh#L42-L46)）のため変更不要。

Closes #126

## Why

これまで `templates/AGENTS.md` には marker block が含まれておらず、template を素直にコピーした consumer が `sync-skills.sh` で codex-cli / gemini-cli adapter を opt-in したとき、`AGENTS.md` に marker がなく snippet 反映が失敗するサイレント故障が起こっていた（`ozzy-labs/agentic-watch#1` Phase 0）。template に marker を組み込むことで新規リポの故障を未然に防ぐ。

## Test plan

- [x] `pnpm run lint:md` passes
- [x] `pnpm run lint:yaml` passes
- [x] `pnpm run lint:shell` passes
- [x] `pnpm run lint:secrets` passes
- [x] `pnpm run test` (bats) passes — 100 / 100
- [x] template から scaffold した repo に対して `check.sh` を実行し、`[PASS] AGENTS.md has @ozzylabs/skills markers` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)