### PR TITLE
feat(sync,sync-skills): seed skills metadata keys and improve init UX

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -97,7 +97,17 @@ commons check /path/to/target-repo
 
 ### Skills 同期（consumer ごとに opt-in）
 
-共有スキルは [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) に置かれ、エージェント別 adapter 出力として `dist/{adapter-id}/` 配下に生成される。consumer は `.commons/sync.yaml` に adapter id を列挙して opt-in する:
+共有スキルは [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) に置かれ、エージェント別 adapter 出力として `dist/{adapter-id}/` 配下に生成される。`commons sync` 初回実行時に `.commons/sync.yaml` に `skills_commit:` / `skills_adapters:` の空値キーと SHA 取得コマンドのコメントが seed されるため、consumer は当該キーを書き換えるだけで opt-in できる。seed される初期形:
+
+```yaml
+# Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA
+# to skills_commit. The skills repo's main HEAD SHA can be obtained via:
+#   gh api repos/ozzy-labs/skills/commits/main --jq .sha
+skills_commit: ""
+skills_adapters: []
+```
+
+埋めた後の metadata:
 
 ```yaml
 # Renovate が @ozzylabs/skills preset 経由で更新
@@ -110,6 +120,8 @@ skills_adapters:
   - gemini-cli # → .gemini/settings.json + AGENTS.md snippet
   - copilot # → .github/copilot-instructions.md snippet
 ```
+
+`skills_adapters` が空のまま `sync-skills.sh` を実行しても fatal にはならず、opt-in 手順（SHA 取得コマンドを含む）を案内して exit 0 で終了する。consumer の sync workflow は opt-out 状態のまま成功し続ける。
 
 Consumer の sync workflow が `skills_commit:` の SHA で `ozzy-labs/skills` をクローンし、`sync-skills.sh` で opt-in した adapter 出力を反映する:
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,17 @@ The earlier `.dev-config/sync.yaml` path was supported as a temporary fallback d
 
 ### Skills sync (opt-in per consumer)
 
-Shared skills live in [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) and are produced as per-agent adapter outputs under `dist/{adapter-id}/`. Consumers opt in by listing adapter ids in `.commons/sync.yaml`:
+Shared skills live in [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) and are produced as per-agent adapter outputs under `dist/{adapter-id}/`. The first run of `commons sync` seeds `.commons/sync.yaml` with empty `skills_commit:` and `skills_adapters:` keys plus a comment naming the exact `gh` command for fetching the SHA — opt-in is then a matter of editing those keys in place. The seeded shape:
+
+```yaml
+# Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA
+# to skills_commit. The skills repo's main HEAD SHA can be obtained via:
+#   gh api repos/ozzy-labs/skills/commits/main --jq .sha
+skills_commit: ""
+skills_adapters: []
+```
+
+Once filled in, the metadata looks like:
 
 ```yaml
 # Tracked by Renovate via the @ozzylabs/skills preset
@@ -110,6 +120,8 @@ skills_adapters:
   - gemini-cli # → .gemini/settings.json + AGENTS.md snippet
   - copilot # → .github/copilot-instructions.md snippet
 ```
+
+Running `sync-skills.sh` against a repo with empty `skills_adapters` is non-fatal: it prints opt-in guidance (including the SHA fetch command) and exits 0, so the consumer's sync workflow keeps succeeding while the repo is still in opt-out state.
 
 The consumer's sync workflow clones `ozzy-labs/skills` at `skills_commit:` and runs `sync-skills.sh` to apply the opted-in adapter outputs:
 

--- a/commons-sync.json
+++ b/commons-sync.json
@@ -5,7 +5,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": ["**/.commons/sync.yaml"],
-      "matchStrings": ["commit:\\s*(?<currentDigest>[a-f0-9]{7,40})"],
+      "matchStrings": ["(?m)^commit:\\s*(?<currentDigest>[a-f0-9]{7,40})"],
       "currentValueTemplate": "main",
       "depNameTemplate": "ozzy-labs/commons",
       "packageNameTemplate": "https://github.com/ozzy-labs/commons",

--- a/sync-skills.sh
+++ b/sync-skills.sh
@@ -174,8 +174,15 @@ while IFS= read -r a; do
   ADAPTERS+=("${a}")
 done < <(read_adapters)
 
+# Empty adapters list is non-fatal: print actionable guidance and exit 0 so
+# manual runs and CI workflows alike can opt-in by editing .commons/sync.yaml.
+# Auto-fetching the SHA would mask config drift — guidance only.
 if [[ ${#ADAPTERS[@]} -eq 0 ]]; then
-  echo "No skills_adapters configured in ${METADATA_FILE}."
+  echo "skills_adapters is empty in ${METADATA_FILE}."
+  echo "  To opt in, list adapter ids (e.g. claude-code, codex-cli, gemini-cli, copilot)"
+  echo "  in skills_adapters, and the skills repo's main HEAD SHA in skills_commit."
+  echo "  Fetch the SHA via:"
+  echo "    gh api repos/ozzy-labs/skills/commits/main --jq .sha"
   echo "Nothing to sync."
   exit 0
 fi

--- a/sync.sh
+++ b/sync.sh
@@ -257,11 +257,15 @@ write_metadata() {
   fi
   SYNCED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 
-  # Preserve skills fields managed by sync-skills.sh
+  # Preserve skills fields managed by sync-skills.sh. We always emit the
+  # skills_commit / skills_adapters keys (with empty defaults if unset) so
+  # consumers can opt in by editing the metadata file directly without
+  # consulting external docs — the explanatory comment below names the
+  # exact gh command to fetch the SHA.
   local existing_skills_commit=""
   local existing_skills_adapters=()
   if [[ -f "${METADATA_FILE}" ]]; then
-    existing_skills_commit="$(grep '^skills_commit:' "${METADATA_FILE}" | awk '{print $2}' || true)"
+    existing_skills_commit="$(grep '^skills_commit:' "${METADATA_FILE}" | awk '{print $2}' | tr -d '"' || true)"
     while IFS= read -r a; do existing_skills_adapters+=("${a}"); done < <(read_yaml_list "${METADATA_FILE}" "skills_adapters")
   fi
 
@@ -271,12 +275,20 @@ write_metadata() {
     echo "# 'pinned' is user-editable — add or remove paths freely"
     echo "commit: ${COMMIT_HASH}"
     echo "synced_at: ${SYNCED_AT}"
+    echo ""
+    echo "# Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA"
+    echo "# to skills_commit. The skills repo's main HEAD SHA can be obtained via:"
+    echo "#   gh api repos/ozzy-labs/skills/commits/main --jq .sha"
     if [[ -n "${existing_skills_commit:-}" ]]; then
       echo "skills_commit: ${existing_skills_commit}"
+    else
+      echo "skills_commit: \"\""
     fi
     if [[ ${#existing_skills_adapters[@]} -gt 0 ]]; then
       echo "skills_adapters:"
       for a in "${existing_skills_adapters[@]}"; do echo "  - ${a}"; done
+    else
+      echo "skills_adapters: []"
     fi
     if [[ ${#pinned_list[@]} -gt 0 ]]; then
       echo "pinned:"

--- a/tests/commons-sync-preset.bats
+++ b/tests/commons-sync-preset.bats
@@ -40,6 +40,15 @@ PRESET_FILE="${BATS_TEST_DIRNAME}/../commons-sync.json"
     "${PRESET_FILE}" >/dev/null
 }
 
+@test "preset regex anchors commit: to the start of a line (avoid skills_commit collision)" {
+  # Without an anchor, the regex would also match `skills_commit: <sha>` and
+  # cause Renovate to bump that field as if it were the commons SHA. The
+  # multiline-mode `^` anchor scopes matching to lines that begin with
+  # `commit:` only.
+  jq -e '.customManagers[0].matchStrings | map(test("\\(\\?m\\)\\^commit:")) | any' \
+    "${PRESET_FILE}" >/dev/null
+}
+
 @test "preset uses git-refs datasource pointing at ozzy-labs/commons main" {
   [ "$(jq -r '.customManagers[0].datasourceTemplate' "${PRESET_FILE}")" = "git-refs" ]
   jq -e '.customManagers[0].packageNameTemplate | test("ozzy-labs/commons")' \

--- a/tests/sync-skills.bats
+++ b/tests/sync-skills.bats
@@ -124,6 +124,15 @@ write_metadata() {
   [[ "$output" == *"Nothing to sync."* ]]
 }
 
+@test "empty skills_adapters prints opt-in guidance" {
+  write_metadata "commit: abc1234"
+  run "${SCRIPT}" -y "${SKILLS_DIST}" "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skills_adapters is empty"* ]]
+  [[ "$output" == *"claude-code, codex-cli, gemini-cli, copilot"* ]]
+  [[ "$output" == *"gh api repos/ozzy-labs/skills/commits/main --jq .sha"* ]]
+}
+
 @test "exits 1 on unknown adapter" {
   write_metadata "skills_adapters:
   - nonexistent-adapter"

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -472,9 +472,10 @@ EOF
 @test "write_metadata preserves skills_commit from existing metadata" {
   "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
 
-  # Simulate sync-skills.sh writing skills_commit to the metadata
+  # Simulate a consumer (or downstream tool) replacing the seeded empty
+  # skills_commit with a real SHA.
   local meta_file="${TARGET_DIR}/.commons/sync.yaml"
-  echo "skills_commit: abc1234567890abc1234567890abc1234567890ab" >>"${meta_file}"
+  sed -i 's|^skills_commit:.*|skills_commit: abc1234567890abc1234567890abc1234567890ab|' "${meta_file}"
 
   # Run sync again (nothing changed, but metadata is rewritten)
   echo "updated skill" >"${SRC_DIR}/dist/.claude/skills/commit/SKILL.md"
@@ -488,9 +489,10 @@ EOF
 @test "write_metadata preserves skills_adapters from existing metadata" {
   "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
 
-  # Simulate sync-skills.sh writing skills_adapters to the metadata
+  # Simulate a consumer replacing the seeded empty skills_adapters with a
+  # populated block-style list.
   local meta_file="${TARGET_DIR}/.commons/sync.yaml"
-  printf "skills_adapters:\n  - claude-code\n  - codex-cli\n" >>"${meta_file}"
+  sed -i 's|^skills_adapters:.*|skills_adapters:\n  - claude-code\n  - codex-cli|' "${meta_file}"
 
   # Run sync again to trigger a metadata rewrite
   echo "updated skill" >"${SRC_DIR}/dist/.claude/skills/commit/SKILL.md"
@@ -503,12 +505,22 @@ EOF
   [[ "$meta" == *"- codex-cli"* ]]
 }
 
-@test "write_metadata does not add skills fields when not present" {
+@test "write_metadata seeds skills fields with empty values when not present" {
   run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
   [ "$status" -eq 0 ]
 
   local meta
   meta="$(cat "${TARGET_DIR}/.commons/sync.yaml")"
-  [[ "$meta" != *"skills_commit"* ]]
-  [[ "$meta" != *"skills_adapters"* ]]
+  [[ "$meta" == *"skills_commit: \"\""* ]]
+  [[ "$meta" == *"skills_adapters: []"* ]]
+}
+
+@test "write_metadata includes skills opt-in guidance comment" {
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+
+  local meta
+  meta="$(cat "${TARGET_DIR}/.commons/sync.yaml")"
+  [[ "$meta" == *"# Skills sync (opt-in)"* ]]
+  [[ "$meta" == *"gh api repos/ozzy-labs/skills/commits/main --jq .sha"* ]]
 }


### PR DESCRIPTION
## Summary

- `sync.sh` の `write_metadata` を更新し、`.commons/sync.yaml` に `skills_commit:` / `skills_adapters:` を**常に出力**するようにした。初回実行時は空値（`skills_commit: ""`、`skills_adapters: []`）と SHA 取得コマンドを案内するコメントを seed する。既存の値があればそのまま保持する。
- `sync-skills.sh` を、`skills_adapters` が空の場合にエラーではなく**opt-in 手順案内**（adapter id 列挙例 + `gh api repos/ozzy-labs/skills/commits/main --jq .sha`）を出力して exit 0 で終わるよう変更した。自動 SHA fetch は副作用が大きいため意図的に避け、案内のみ。
- README.md / README.ja.md の skills sync セクションを更新し、seed される初期形と空状態時の non-fatal 挙動を明示。
- 既存テストを実使用シナリオに合わせて更新（`>>` append → `sed` 置換）し、新たに seed の確認テスト 2 件と sync-skills.sh のガイダンス出力テスト 1 件を追加。

Closes #127

## Why

Issue #127 で報告された通り、skills opt-in の初回手順が分かりにくかった。`.commons/sync.yaml` に `skills_commit:` / `skills_adapters:` の空キーが事前に存在せず、「どこに何を書けばよいか」「初期 SHA をどう取得するか」がドキュメント参照なしには分からなかった。Skills 関連キーをファイル内のコメントとともに seed することで、対象の編集箇所と SHA 取得方法が**ファイル内で自明**になる。

## Test plan

- [x] `pnpm run test` (bats) — 103 / 103 通過
- [x] `pnpm run lint:md` / `lint:yaml` / `lint:shell` / `lint:secrets` 通過
- [x] 新規リポで `sync.sh -y` 実行 → `.commons/sync.yaml` に skills 空値キー + コメントが seed されることを確認
- [x] `sync-skills.sh` を skills_adapters 空状態で実行 → opt-in 手順案内が表示され exit 0
- [x] 既存の skills_adapters 値を持つ `.commons/sync.yaml` に対して再度 `sync.sh` 実行 → 既存値が保持される

🤖 Generated with [Claude Code](https://claude.com/claude-code)