### PR TITLE
feat: add init-templates.sh for placeholder substitution and metadata setup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -34,6 +34,7 @@ templates/           -> scaffold 専用ファイル（新規リポ作成時に�
 sync.sh              -> 同期スクリプト
 sync-skills.sh       -> @ozzylabs/skills adapter 同期スクリプト（consumer ごとに opt-in）
 setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト
+init-templates.sh    -> templates のプレースホルダ置換とリポメタデータ反映
 ```
 
 `templates/` には各リポでカスタマイズ前提の雛形（プロジェクト概要・tech stack・利用スキル等）を置く。`sync.sh` の対象外なので、新規リポ初期化時に一度だけ手動コピーしてその後はリポ側で編集する。
@@ -51,6 +52,7 @@ setup-repo.sh        -> GitHub リポジトリ初期設定スクリプト
 #   check     規約適合度診断
 #   setup     リポジトリ初期設定
 #   skills    スキル・アダプター同期
+#   init      templates のブートストラップとメタデータ反映
 ```
 
 ### 同期 (Sync)
@@ -149,6 +151,27 @@ Snippet 対象（`AGENTS.md` / `.github/copilot-instructions.md`）は対象フ�
 ```
 
 マージルール（squash のみ）、ブランチ保護（Rulesets）、セキュリティ設定、Conventional Commits ラベルを設定する。設計方針は [ADR-0004](docs/adr/0004-repo-setup-with-rulesets.md) を参照。
+
+### Templates のブートストラップ（`commons init`）
+
+`init-templates.sh` は `templates/AGENTS.md` `templates/CLAUDE.md` を target リポにコピーし、`{{project_name}}` `{{description}}` プレースホルダを置換、加えて `--description` `--topics` 指定時には GitHub リポの description / topics を一括反映する。`setup-repo.sh` が ozzy-labs 共通の GitHub 設定を担当するのに対し、本スクリプトはリポ固有のブートストラップ内容を担当する補完関係。
+
+```bash
+# フル ブートストラップ（ファイル + GitHub メタデータ）
+/path/to/commons/init-templates.sh \
+  --name agentic-watch \
+  --description "ブログを監視するマルチエージェント CLI..." \
+  --topics ai,cli,multi-agent,claude-code,codex,gemini \
+  /path/to/agentic-watch
+
+# ファイルのみ（gh API 呼び出しをスキップ）
+/path/to/commons/init-templates.sh --name <name> --skip-gh-edit /path/to/repo
+
+# 変更内容をプレビュー
+/path/to/commons/init-templates.sh --name <name> --dry-run /path/to/repo
+```
+
+`--name` は必須。target に既存の `AGENTS.md` / `CLAUDE.md` がある場合は diff を表示してアボートする（`--force` で上書き）。`gh api` 用のリポは target の `origin` remote から自動検出するが、`--repo owner/repo` で明示指定も可能。
 
 ### 自動同期（定期 PR）
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ templates/           -> Scaffold-only files (copied manually for new repos, neve
 sync.sh              -> Sync script
 sync-skills.sh       -> @ozzylabs/skills adapter sync script (opt-in per consumer)
 setup-repo.sh        -> GitHub repository setup script
+init-templates.sh    -> Bootstrap templates with placeholder substitution + repo metadata
 ```
 
 `templates/` ships starter content that every repo customizes (project name, tech stack, available skills). It is intentionally outside `dist/` so `sync.sh` never touches it — copy these files once when bootstrapping a new repo and edit in place.
@@ -51,6 +52,7 @@ Shared skills (`.agents/skills/`, `.claude/skills/`) are no longer distributed f
 #   check     Run health check
 #   setup     Initialize repository
 #   skills    Sync skills adapters
+#   init      Bootstrap templates and metadata
 ```
 
 ### Sync
@@ -149,6 +151,27 @@ Snippet targets (`AGENTS.md`, `.github/copilot-instructions.md`) must already co
 ```
 
 Sets merge rules (squash only), branch protection (Rulesets), security settings, and Conventional Commits labels. See [ADR-0004](docs/adr/0004-repo-setup-with-rulesets.md) for design decisions.
+
+### Bootstrap templates (`commons init`)
+
+`init-templates.sh` copies `templates/AGENTS.md` and `templates/CLAUDE.md` into a target repo, substitutes `{{project_name}}` and `{{description}}` placeholders, and (when invoked with `--description` or `--topics`) applies the GitHub repo description and topics in one shot. It complements `setup-repo.sh`: that script handles ozzy-labs-wide GitHub settings, while this one handles per-repo bootstrap content.
+
+```bash
+# Full bootstrap (file ops + GitHub metadata)
+/path/to/commons/init-templates.sh \
+  --name agentic-watch \
+  --description "Multi-agent CLI that watches blogs..." \
+  --topics ai,cli,multi-agent,claude-code,codex,gemini \
+  /path/to/agentic-watch
+
+# Files only (no gh API calls)
+/path/to/commons/init-templates.sh --name <name> --skip-gh-edit /path/to/repo
+
+# Preview changes
+/path/to/commons/init-templates.sh --name <name> --dry-run /path/to/repo
+```
+
+`--name` is required. Existing `AGENTS.md` / `CLAUDE.md` files in the target are protected: the script aborts with a diff summary unless `--force` is passed. The repo for `gh api` is auto-detected from the target's `origin` remote, or pass `--repo owner/repo` to override.
 
 ### Automated sync (scheduled PR)
 

--- a/commons
+++ b/commons
@@ -16,6 +16,7 @@ usage() {
   echo "  check     Run health check (wrapper for check.sh)"
   echo "  setup     Initialize repository (wrapper for setup-repo.sh)"
   echo "  skills    Sync skills adapters (wrapper for sync-skills.sh)"
+  echo "  init      Bootstrap templates and metadata (wrapper for init-templates.sh)"
 }
 
 if [[ $# -lt 1 ]]; then
@@ -38,6 +39,9 @@ case "${COMMAND}" in
     ;;
   skills)
     exec "${SCRIPT_DIR}/sync-skills.sh" "$@"
+    ;;
+  init)
+    exec "${SCRIPT_DIR}/init-templates.sh" "$@"
     ;;
   help | --help | -h)
     usage

--- a/init-templates.sh
+++ b/init-templates.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# init-templates.sh
+#
+# Bootstrap a new repo from commons/templates/: copy AGENTS.md and CLAUDE.md
+# into the target, substitute Mustache-style placeholders, and (optionally)
+# apply description / topics to the GitHub repo via the gh CLI.
+#
+# Usage:
+#   init-templates.sh [options] <target-repo-path>
+#
+# Options:
+#   --name <name>         Required. Substituted for {{project_name}}.
+#   --description <desc>  Substituted for {{description}}; also applied to
+#                         the GitHub repo if --repo (or origin) is set.
+#   --topics <t1,t2,...>  Comma-separated topics; replaces the repo's topic
+#                         list on GitHub. Requires --repo or origin remote.
+#   --repo <owner/repo>   Override repo detection. Default: parsed from the
+#                         target's `git remote get-url origin`.
+#   --skip-gh-edit        Skip the gh API calls; only do the file ops.
+#   --force               Overwrite existing template files in the target
+#                         without prompting.
+#   --dry-run             Show what would happen without changing anything.
+#
+# Behavior:
+#   1. Copy templates/AGENTS.md and templates/CLAUDE.md to <target>.
+#   2. Substitute {{project_name}} and {{description}} placeholders.
+#   3. If --description or --topics is given, run gh api to update the repo
+#      metadata. (Skipped when --skip-gh-edit, --dry-run, or no repo.)
+#   4. Existing files in the target are protected: aborts with a diff
+#      summary unless --force is passed.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATES_DIR="${SCRIPT_DIR}/templates"
+
+NAME=""
+DESCRIPTION=""
+TOPICS=""
+REPO=""
+SKIP_GH_EDIT=false
+FORCE=false
+DRY_RUN=false
+
+while [[ "${1:-}" == --* ]]; do
+  case "$1" in
+  --name)
+    NAME="$2"
+    shift 2
+    ;;
+  --description)
+    DESCRIPTION="$2"
+    shift 2
+    ;;
+  --topics)
+    TOPICS="$2"
+    shift 2
+    ;;
+  --repo)
+    REPO="$2"
+    shift 2
+    ;;
+  --skip-gh-edit)
+    SKIP_GH_EDIT=true
+    shift
+    ;;
+  --force)
+    FORCE=true
+    shift
+    ;;
+  --dry-run)
+    DRY_RUN=true
+    shift
+    ;;
+  *)
+    echo "Unknown option: $1" >&2
+    exit 1
+    ;;
+  esac
+done
+
+usage() {
+  echo "Usage:" >&2
+  echo "  $0 [options] <target-repo-path>" >&2
+  echo "  Required:" >&2
+  echo "    --name <name>           Substituted for {{project_name}}" >&2
+  echo "  Optional:" >&2
+  echo "    --description <desc>    Substituted for {{description}} and applied to repo" >&2
+  echo "    --topics <t1,t2,...>    Comma-separated topics applied to repo" >&2
+  echo "    --repo <owner/repo>     Override repo detection (default: target's origin)" >&2
+  echo "    --skip-gh-edit          Skip gh metadata update" >&2
+  echo "    --force                 Overwrite existing files without prompting" >&2
+  echo "    --dry-run               Show what would happen without changing anything" >&2
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+if [[ -z "${NAME}" ]]; then
+  echo "Error: --name is required" >&2
+  usage
+  exit 1
+fi
+
+TARGET_DIR="${1%/}"
+
+if [[ ! -d "${TARGET_DIR}" ]]; then
+  echo "Error: target directory not found: ${TARGET_DIR}" >&2
+  exit 1
+fi
+
+# Auto-detect repo from target's git remote if not specified.
+if [[ -z "${REPO}" ]] && [[ -d "${TARGET_DIR}/.git" ]]; then
+  if origin_url="$(git -C "${TARGET_DIR}" remote get-url origin 2>/dev/null)"; then
+    # Strip git@github.com: or https://github.com/ prefix and trailing .git
+    REPO="${origin_url#git@github.com:}"
+    REPO="${REPO#https://github.com/}"
+    REPO="${REPO%.git}"
+  fi
+fi
+
+# --- Plan phase: figure out what would change ---
+
+new_files=()
+overwrite_files=()
+unchanged_files=()
+template_files=("AGENTS.md" "CLAUDE.md")
+
+# Render a template by substituting {{project_name}} and {{description}}.
+# Uses awk with -v and `index()`-based literal substring replacement so user
+# values containing regex / sed metacharacters or `&` (which would normally
+# expand to the matched text inside gsub's replacement) are interpreted
+# verbatim.
+render_template() {
+  local src="$1"
+  awk -v name="${NAME}" -v desc="${DESCRIPTION}" '
+    function lit_replace(line, needle, repl,    out, idx, nlen) {
+      out = ""
+      nlen = length(needle)
+      while ((idx = index(line, needle)) > 0) {
+        out = out substr(line, 1, idx - 1) repl
+        line = substr(line, idx + nlen)
+      }
+      return out line
+    }
+    {
+      $0 = lit_replace($0, "{{project_name}}", name)
+      $0 = lit_replace($0, "{{description}}", desc)
+      print
+    }
+  ' "${src}"
+}
+
+for f in "${template_files[@]}"; do
+  src="${TEMPLATES_DIR}/${f}"
+  if [[ ! -f "${src}" ]]; then
+    echo "Error: template not found: ${src}" >&2
+    exit 1
+  fi
+  dest="${TARGET_DIR}/${f}"
+  if [[ ! -f "${dest}" ]]; then
+    new_files+=("${f}")
+    continue
+  fi
+  rendered="$(render_template "${src}")"
+  if [[ "$(cat "${dest}")" == "${rendered}" ]]; then
+    unchanged_files+=("${f}")
+  else
+    overwrite_files+=("${f}")
+  fi
+done
+
+# --- Display plan ---
+
+echo "Templates plan (target: ${TARGET_DIR}):"
+for f in "${new_files[@]+"${new_files[@]}"}"; do
+  echo "  new:       ${f}"
+done
+for f in "${overwrite_files[@]+"${overwrite_files[@]}"}"; do
+  echo "  overwrite: ${f}"
+done
+for f in "${unchanged_files[@]+"${unchanged_files[@]}"}"; do
+  echo "  unchanged: ${f}"
+done
+
+# Plan gh metadata update
+GH_DESC=false
+GH_TOPICS=false
+if ! ${SKIP_GH_EDIT}; then
+  if [[ -n "${DESCRIPTION}" ]] && [[ -n "${REPO}" ]]; then
+    GH_DESC=true
+  fi
+  if [[ -n "${TOPICS}" ]] && [[ -n "${REPO}" ]]; then
+    GH_TOPICS=true
+  fi
+fi
+
+if ${GH_DESC} || ${GH_TOPICS}; then
+  echo ""
+  echo "GitHub metadata (${REPO}):"
+  ${GH_DESC} && echo "  description: ${DESCRIPTION}"
+  ${GH_TOPICS} && echo "  topics:      ${TOPICS}"
+fi
+
+# --- Existing-file protection ---
+
+if [[ ${#overwrite_files[@]} -gt 0 ]] && ! ${FORCE} && ! ${DRY_RUN}; then
+  echo ""
+  echo "Refusing to overwrite existing files. Pass --force to apply." >&2
+  for f in "${overwrite_files[@]}"; do
+    echo "  diff for ${f}:" >&2
+    diff -u "${TARGET_DIR}/${f}" <(render_template "${TEMPLATES_DIR}/${f}") --label "current/${f}" --label "rendered/${f}" || true
+  done
+  exit 1
+fi
+
+if ${DRY_RUN}; then
+  echo ""
+  echo "Dry run — no changes made."
+  exit 0
+fi
+
+# --- Apply file ops ---
+
+for f in "${new_files[@]+"${new_files[@]}"}" "${overwrite_files[@]+"${overwrite_files[@]}"}"; do
+  [[ -z "${f}" ]] && continue
+  src="${TEMPLATES_DIR}/${f}"
+  dest="${TARGET_DIR}/${f}"
+  render_template "${src}" >"${dest}"
+  echo "  write: ${f}"
+done
+
+# --- Apply gh metadata ---
+
+if ${GH_DESC} || ${GH_TOPICS}; then
+  if ! command -v gh &>/dev/null; then
+    echo "Error: gh CLI is not installed. Skipping repo metadata update." >&2
+    exit 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    echo "Error: gh CLI is not authenticated. Run 'gh auth login' first." >&2
+    exit 1
+  fi
+
+  if ${GH_DESC}; then
+    if gh api --method PATCH "/repos/${REPO}" -f "description=${DESCRIPTION}" >/dev/null; then
+      echo "  gh: description updated"
+    else
+      echo "  ⚠ gh: description update failed" >&2
+    fi
+  fi
+
+  if ${GH_TOPICS}; then
+    # GitHub's PUT /repos/{owner}/{repo}/topics expects {"names": [...]} and
+    # replaces the entire topic list. Build --field names[]= for each topic.
+    topic_args=()
+    IFS=',' read -ra TOPIC_ARRAY <<<"${TOPICS}"
+    for t in "${TOPIC_ARRAY[@]}"; do
+      # Trim whitespace
+      t="${t#"${t%%[![:space:]]*}"}"
+      t="${t%"${t##*[![:space:]]}"}"
+      [[ -z "${t}" ]] && continue
+      topic_args+=(--field "names[]=${t}")
+    done
+    if gh api --method PUT "/repos/${REPO}/topics" "${topic_args[@]}" >/dev/null; then
+      echo "  gh: topics updated"
+    else
+      echo "  ⚠ gh: topics update failed" >&2
+    fi
+  fi
+fi
+
+echo ""
+echo "Templates init complete."

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -11,7 +11,7 @@
 
 ## プロジェクト概要
 
-`<project-name>`: <description>
+`{{project_name}}`: {{description}}
 
 ## Tech Stack
 

--- a/tests/init-templates.bats
+++ b/tests/init-templates.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  TEST_DIR="$(mktemp -d)"
+  TARGET_DIR="${TEST_DIR}/target"
+  mkdir -p "${TARGET_DIR}"
+  git -C "${TARGET_DIR}" init -q
+  git -C "${TARGET_DIR}" config user.email "test@example.com"
+  git -C "${TARGET_DIR}" config user.name "Test User"
+  git -C "${TARGET_DIR}" commit -q --allow-empty -m "init"
+
+  SCRIPT="${BATS_TEST_DIRNAME}/../init-templates.sh"
+}
+
+teardown() {
+  rm -rf "${TEST_DIR}"
+}
+
+@test "exits 1 with usage when no arguments given" {
+  run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Usage:"* ]]
+}
+
+@test "exits 1 when --name is missing" {
+  run "${SCRIPT}" --skip-gh-edit "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--name is required"* ]]
+}
+
+@test "exits 1 on unknown option" {
+  run "${SCRIPT}" --invalid "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Unknown option: --invalid"* ]]
+}
+
+@test "exits 1 when target directory does not exist" {
+  run "${SCRIPT}" --name foo --skip-gh-edit "${TEST_DIR}/nonexistent"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"target directory not found"* ]]
+}
+
+@test "copies templates and substitutes placeholders" {
+  run "${SCRIPT}" \
+    --name agentic-watch \
+    --description "Multi-agent CLI" \
+    --skip-gh-edit \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+
+  [ -f "${TARGET_DIR}/AGENTS.md" ]
+  [ -f "${TARGET_DIR}/CLAUDE.md" ]
+  grep -q "agentic-watch" "${TARGET_DIR}/AGENTS.md"
+  grep -q "Multi-agent CLI" "${TARGET_DIR}/AGENTS.md"
+
+  # No literal placeholders remain
+  run ! grep -q "{{project_name}}" "${TARGET_DIR}/AGENTS.md"
+  run ! grep -q "{{description}}" "${TARGET_DIR}/AGENTS.md"
+}
+
+@test "leaves description placeholder empty when --description not given" {
+  run "${SCRIPT}" --name foo --skip-gh-edit "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  grep -q "foo" "${TARGET_DIR}/AGENTS.md"
+  # The placeholder is replaced with empty string when no description given
+  run ! grep -q "{{description}}" "${TARGET_DIR}/AGENTS.md"
+}
+
+@test "refuses to overwrite existing files without --force" {
+  echo "custom AGENTS.md" >"${TARGET_DIR}/AGENTS.md"
+  run "${SCRIPT}" --name foo --skip-gh-edit "${TARGET_DIR}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Refusing to overwrite"* ]]
+  [[ "$output" == *"--force"* ]]
+  # Existing file preserved
+  [ "$(cat "${TARGET_DIR}/AGENTS.md")" = "custom AGENTS.md" ]
+}
+
+@test "--force overwrites existing files" {
+  echo "custom AGENTS.md" >"${TARGET_DIR}/AGENTS.md"
+  run "${SCRIPT}" --name foo --description "desc" --skip-gh-edit --force "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  grep -q "foo" "${TARGET_DIR}/AGENTS.md"
+  run ! grep -q "custom AGENTS.md" "${TARGET_DIR}/AGENTS.md"
+}
+
+@test "unchanged files are reported as unchanged and not rewritten" {
+  # First run creates the files
+  "${SCRIPT}" --name foo --description "desc" --skip-gh-edit "${TARGET_DIR}"
+  local first_mtime
+  first_mtime="$(stat -c %Y "${TARGET_DIR}/AGENTS.md")"
+
+  # Sleep 1s so mtime would visibly change if rewritten
+  sleep 1
+
+  # Second run with same args should be no-op
+  run "${SCRIPT}" --name foo --description "desc" --skip-gh-edit "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unchanged: AGENTS.md"* ]]
+  [[ "$output" == *"unchanged: CLAUDE.md"* ]]
+}
+
+@test "--dry-run shows plan without modifying files" {
+  run "${SCRIPT}" \
+    --name agentic-watch \
+    --description "desc" \
+    --topics ai,cli \
+    --repo ozzy-labs/agentic-watch \
+    --dry-run \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"new:"*"AGENTS.md"* ]]
+  [[ "$output" == *"new:"*"CLAUDE.md"* ]]
+  [[ "$output" == *"description: desc"* ]]
+  [[ "$output" == *"topics:"*"ai,cli"* ]]
+  [[ "$output" == *"Dry run"* ]]
+  # Files not actually created
+  [ ! -f "${TARGET_DIR}/AGENTS.md" ]
+  [ ! -f "${TARGET_DIR}/CLAUDE.md" ]
+}
+
+@test "--dry-run respects existing files (no overwrite check failure)" {
+  echo "custom" >"${TARGET_DIR}/AGENTS.md"
+  run "${SCRIPT}" --name foo --skip-gh-edit --dry-run "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"overwrite:"*"AGENTS.md"* ]]
+  # Existing file preserved
+  [ "$(cat "${TARGET_DIR}/AGENTS.md")" = "custom" ]
+}
+
+@test "auto-detects repo from target's origin remote" {
+  git -C "${TARGET_DIR}" remote add origin https://github.com/test-org/test-repo.git
+  run "${SCRIPT}" \
+    --name foo \
+    --description "desc" \
+    --dry-run \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GitHub metadata (test-org/test-repo)"* ]]
+}
+
+@test "auto-detects repo from ssh-style origin remote" {
+  git -C "${TARGET_DIR}" remote add origin git@github.com:test-org/test-repo.git
+  run "${SCRIPT}" \
+    --name foo \
+    --description "desc" \
+    --dry-run \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GitHub metadata (test-org/test-repo)"* ]]
+}
+
+@test "--repo overrides remote detection" {
+  git -C "${TARGET_DIR}" remote add origin https://github.com/wrong/wrong.git
+  run "${SCRIPT}" \
+    --name foo \
+    --description "desc" \
+    --repo override/repo \
+    --dry-run \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"GitHub metadata (override/repo)"* ]]
+}
+
+@test "--skip-gh-edit suppresses GitHub metadata plan" {
+  run "${SCRIPT}" \
+    --name foo \
+    --description "desc" \
+    --topics ai,cli \
+    --repo o/r \
+    --skip-gh-edit \
+    --dry-run \
+    "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  run ! grep -q "GitHub metadata" <<<"$output"
+}
+
+@test "no GitHub metadata block when neither description nor topics given" {
+  run "${SCRIPT}" --name foo --repo o/r --dry-run "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  run ! grep -q "GitHub metadata" <<<"$output"
+}
+
+@test "templates with substitution are valid markdown (no broken placeholders)" {
+  "${SCRIPT}" \
+    --name "my-project" \
+    --description "A description with: special chars & symbols" \
+    --skip-gh-edit \
+    "${TARGET_DIR}"
+
+  # No partial placeholder leftovers
+  run ! grep -qE '\{\{[a-z_]+\}\}' "${TARGET_DIR}/AGENTS.md"
+  run ! grep -qE '\{\{[a-z_]+\}\}' "${TARGET_DIR}/CLAUDE.md"
+
+  # Special chars preserved
+  grep -q "special chars & symbols" "${TARGET_DIR}/AGENTS.md"
+}


### PR DESCRIPTION
## Summary

- 新スクリプト `init-templates.sh` を追加。`commons/templates/` の `AGENTS.md` `CLAUDE.md` を target リポにコピーし、`{{project_name}}` `{{description}}` プレースホルダを置換、必要に応じて `gh api` で GitHub リポの description / topics を一括反映する。
- `templates/AGENTS.md` のプレースホルダを `<project-name>` `<description>` から Mustache 風 `{{project_name}}` `{{description}}` に変更。境界が曖昧で誤爆しやすかったため。
- `commons` CLI dispatcher に `init` サブコマンドを追加。
- README.md / README.ja.md を更新（CLI コマンド一覧 + 専用セクション）。
- bats テスト 17 件追加。

Closes #129

## Why

これまで新規リポの bootstrap 時、placeholder 置換と `gh repo edit --add-topic` の繰り返し実行が手作業で散逸していた（Issue #129 で 16 回手動実行と報告）。`init-templates.sh` で一括化することで、`commons init --name X --description "..." --topics a,b,c <target>` 一発で完了する。

## 設計上の判断

- **既存ファイル保護:** target に既存の `AGENTS.md` / `CLAUDE.md` がある場合は unified diff を表示してアボート。`--force` で上書き可能。
- **リポ自動検出:** `gh api` 用の `<owner/repo>` は target の `origin` remote から自動検出（https / ssh 両対応）。`--repo` で明示上書き可能。
- **トピック書き込み:** `PUT /repos/:owner/:repo/topics` を使い**全置換**。`gh repo edit --add-topic` の累積方式に比べ idempotent で予測可能。
- **placeholder 置換は awk + `index()` リテラル置換:** ユーザー値に `&` `\` 等の regex / sed メタ文字が含まれても誤動作しないようにした（実装中に awk gsub の `&` 展開バグを発見・修正）。
- **scope 限定:** Issue が却下した `--tech-stack` オプション・`setup-repo.sh` への混入は本 PR でも採用しない。

## Test plan

- [x] `pnpm run test` (bats): 121 / 121 通過（init-templates.bats 17 件含む）
- [x] `pnpm run lint:md` / `lint:yaml` / `lint:shell` / `lint:secrets`: 全通過
- [x] 手動: `--name foo --description "x & y" --skip-gh-edit /tmp/...` で `&` を含む description が正しく置換されることを確認
- [x] 手動: 既存ファイルがある状態で `--force` なしで実行 → diff を表示して exit 1
- [x] 手動: `--dry-run` がファイルを変更しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)