### PR TITLE
feat(setup-repo,sync,init-templates): print next-step hints after completion

### DIFF
--- a/dist/.github/workflows/sync-commons.yaml
+++ b/dist/.github/workflows/sync-commons.yaml
@@ -47,7 +47,7 @@ jobs:
             echo "No changes to sync."
             exit 0
           fi
-          bash .sync-commons/sync.sh --yes "$GITHUB_WORKSPACE"
+          bash .sync-commons/sync.sh --yes --quiet "$GITHUB_WORKSPACE"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Remove temporary clone

--- a/init-templates.sh
+++ b/init-templates.sh
@@ -41,6 +41,7 @@ REPO=""
 SKIP_GH_EDIT=false
 FORCE=false
 DRY_RUN=false
+QUIET=false
 
 while [[ "${1:-}" == --* ]]; do
   case "$1" in
@@ -72,6 +73,10 @@ while [[ "${1:-}" == --* ]]; do
     DRY_RUN=true
     shift
     ;;
+  --quiet)
+    QUIET=true
+    shift
+    ;;
   *)
     echo "Unknown option: $1" >&2
     exit 1
@@ -91,6 +96,7 @@ usage() {
   echo "    --skip-gh-edit          Skip gh metadata update" >&2
   echo "    --force                 Overwrite existing files without prompting" >&2
   echo "    --dry-run               Show what would happen without changing anything" >&2
+  echo "    --quiet                 Suppress next-step hints (CI use)" >&2
 }
 
 if [[ $# -lt 1 ]]; then
@@ -274,3 +280,11 @@ fi
 
 echo ""
 echo "Templates init complete."
+
+if ! ${QUIET}; then
+  echo ""
+  echo "Next steps:"
+  echo "  1. Edit AGENTS.md / CLAUDE.md to fill in tech stack and project specifics"
+  echo "  2. Add project-specific files (package.json, src/, etc.)"
+  echo "  3. Commit and open a PR (chore/bootstrap → main)"
+fi

--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -9,10 +9,15 @@ set -euo pipefail
 
 # Parse arguments
 DRY_RUN=false
+QUIET=false
 while [[ "${1:-}" == --* ]]; do
   case "$1" in
   --dry-run)
     DRY_RUN=true
+    shift
+    ;;
+  --quiet)
+    QUIET=true
     shift
     ;;
   *)
@@ -27,6 +32,7 @@ if [[ $# -lt 1 ]]; then
   echo "  $0 [options] <owner/repo>" >&2
   echo "  Options:" >&2
   echo "    --dry-run   Show what would be configured without making changes" >&2
+  echo "    --quiet     Suppress next-step hints (CI use)" >&2
   exit 1
 fi
 
@@ -248,3 +254,13 @@ echo "  ✓ Conventional Commits labels: created"
 
 echo ""
 echo "Setup complete."
+
+if ! ${QUIET}; then
+  echo ""
+  echo "Next steps:"
+  echo "  1. Sync shared config:    <commons>/sync.sh /path/to/repo"
+  echo "  2. Bootstrap templates:   <commons>/init-templates.sh --name <name> /path/to/repo"
+  echo "  3. Add project-specific files and open a PR (chore/bootstrap → main)"
+  echo ""
+  echo "Direct push to main is now blocked by ruleset; subsequent changes go via PR."
+fi

--- a/sync.sh
+++ b/sync.sh
@@ -16,6 +16,7 @@ DIST_DIR="${SCRIPT_DIR}/dist"
 YES=false
 DRY_RUN=false
 CHECK=false
+QUIET=false
 while [[ "${1:-}" == -* ]]; do
   case "$1" in
   -y | --yes)
@@ -28,6 +29,10 @@ while [[ "${1:-}" == -* ]]; do
     ;;
   --check)
     CHECK=true
+    shift
+    ;;
+  --quiet)
+    QUIET=true
     shift
     ;;
   *)
@@ -44,6 +49,7 @@ if [[ $# -lt 1 ]]; then
   echo "    -y, --yes   Sync without confirmation" >&2
   echo "    --dry-run   Show what would be synced without copying" >&2
   echo "    --check     Exit 1 if non-pinned files are out of sync (for CI)" >&2
+  echo "    --quiet     Suppress next-step hints (CI use)" >&2
   exit 1
 fi
 
@@ -53,6 +59,21 @@ if [[ ! -d "${TARGET_DIR}/.git" ]]; then
   echo "Error: ${TARGET_DIR} is not a git repository" >&2
   exit 1
 fi
+
+# Print bootstrap-oriented next-step hints. Suppressed by --quiet so the
+# scheduled sync-commons workflow doesn't clutter CI logs on every run.
+print_next_steps() {
+  ${QUIET} && return 0
+  echo ""
+  echo "Next steps:"
+  echo "  1. Bootstrap templates (if a fresh repo):"
+  echo "       ${SCRIPT_DIR}/init-templates.sh --name <name> ${TARGET_DIR}"
+  echo "  2. (Optional) Opt in to @ozzylabs/skills:"
+  echo "       Edit .commons/sync.yaml — set skills_commit and skills_adapters"
+  echo "       Run:  ${SCRIPT_DIR}/sync-skills.sh -y <skills-repo>/dist ${TARGET_DIR}"
+  echo "  3. Add project-specific files (package.json, src/, etc.)"
+  echo "  4. Open a PR (chore/bootstrap → main)"
+}
 
 # --- Metadata helpers ---
 #
@@ -407,6 +428,7 @@ if [[ "${YES}" == true ]]; then
   echo "  write: ${METADATA_REL}"
   echo ""
   echo "Sync complete."
+  print_next_steps
   exit 0
 fi
 
@@ -499,3 +521,4 @@ fi
 
 echo ""
 echo "Sync complete."
+print_next_steps

--- a/tests/init-templates.bats
+++ b/tests/init-templates.bats
@@ -183,6 +183,21 @@ teardown() {
   run ! grep -q "GitHub metadata" <<<"$output"
 }
 
+@test "prints next-step hints by default" {
+  run "${SCRIPT}" --name foo --skip-gh-edit "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Templates init complete."* ]]
+  [[ "$output" == *"Next steps:"* ]]
+  [[ "$output" == *"chore/bootstrap"* ]]
+}
+
+@test "--quiet suppresses next-step hints" {
+  run "${SCRIPT}" --name foo --skip-gh-edit --quiet "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Templates init complete."* ]]
+  run ! grep -q "Next steps:" <<<"$output"
+}
+
 @test "templates with substitution are valid markdown (no broken placeholders)" {
   "${SCRIPT}" \
     --name "my-project" \

--- a/tests/setup-repo.bats
+++ b/tests/setup-repo.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   SCRIPT="${BATS_TEST_DIRNAME}/../setup-repo.sh"
 }
@@ -100,4 +102,26 @@ setup() {
   run "${SCRIPT}"
   [ "$status" -eq 1 ]
   [[ "$output" == *"--dry-run"* ]]
+}
+
+@test "usage message includes --quiet option" {
+  run "${SCRIPT}"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--quiet"* ]]
+}
+
+@test "--dry-run prints next-step hints by default" {
+  run "${SCRIPT}" --dry-run ozzy-labs/commons
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Setup complete."* ]]
+  [[ "$output" == *"Next steps:"* ]]
+  [[ "$output" == *"sync.sh"* ]]
+  [[ "$output" == *"init-templates.sh"* ]]
+}
+
+@test "--quiet suppresses next-step hints" {
+  run "${SCRIPT}" --dry-run --quiet ozzy-labs/commons
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Setup complete."* ]]
+  run ! grep -q "Next steps:" <<<"$output"
 }

--- a/tests/sync.bats
+++ b/tests/sync.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   TEST_DIR="$(mktemp -d)"
 
@@ -523,4 +525,28 @@ EOF
   meta="$(cat "${TARGET_DIR}/.commons/sync.yaml")"
   [[ "$meta" == *"# Skills sync (opt-in)"* ]]
   [[ "$meta" == *"gh api repos/ozzy-labs/skills/commits/main --jq .sha"* ]]
+}
+
+@test "prints next-step hints after Sync complete in -y mode" {
+  run "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sync complete."* ]]
+  [[ "$output" == *"Next steps:"* ]]
+  [[ "$output" == *"init-templates.sh"* ]]
+  [[ "$output" == *"sync-skills.sh"* ]]
+}
+
+@test "--quiet suppresses next-step hints" {
+  run "${SRC_DIR}/sync.sh" -y --quiet "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Sync complete."* ]]
+  run ! grep -q "Next steps:" <<<"$output"
+}
+
+@test "--check does not print next-step hints" {
+  # First sync to bring target up to date
+  "${SRC_DIR}/sync.sh" -y "${TARGET_DIR}"
+  run "${SRC_DIR}/sync.sh" --check "${TARGET_DIR}"
+  [ "$status" -eq 0 ]
+  run ! grep -q "Next steps:" <<<"$output"
 }


### PR DESCRIPTION
## Summary

- `setup-repo.sh` `sync.sh` `init-templates.sh` の各スクリプトに完了時の "Next steps:" ヒントを追加。新規リポ bootstrap 時の「次は何？」を README に戻らず把握できる。
- 各スクリプトに `--quiet` フラグを追加（CI 用に suppress）。
- 配布される `dist/.github/workflows/sync-commons.yaml` の sync.sh 呼び出しに `--quiet` を追加し、定期同期で Action ログを汚さないようにした。
- 文言は 3 スクリプト間で統一: setup-repo → sync → init-templates → PR の流れ。
- bats テスト 8 件追加（next-step 出力 + `--quiet` suppress + `--check` で hint 出力なし）。

Closes #130

## Why

`ozzy-labs/agentic-watch#1` Phase 0 で報告された通り、新規 bootstrap 時に各スクリプト完了後「次は何？」を判断するため README を行き来していた。低コストで解消できる UX 摩擦のため、各スクリプト末尾に次の手順を直接表示する。

## Test plan

- [x] `pnpm run test` (bats): 129 / 129 通過
- [x] `pnpm run lint:md` / `lint:yaml` / `lint:shell` / `lint:secrets` / prettier (sync-commons.yaml): 全通過
- [x] 手動: `setup-repo.sh --dry-run` で Next steps が表示される / `--quiet` で suppress される
- [x] 手動: `sync.sh -y` で Next steps 表示 / `--quiet` で suppress
- [x] 手動: `init-templates.sh --name foo --skip-gh-edit` で Next steps 表示 / `--quiet` で suppress
- [x] 手動: `sync.sh --check` では hint を出さない（CI 想定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)