### PR TITLE
docs(readme): add 'Quick start: bootstrap a new repo' walk-through

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -41,6 +41,53 @@ init-templates.sh    -> templates のプレースホルダ置換とリポメタ�
 
 共有スキル（`.agents/skills/`、`.claude/skills/`）は本リポからの配布対象外。SSOT は [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) に置き、各 consumer リポは `@ozzylabs/skills` の Renovate preset 経由で取り込む（[ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md)）。
 
+## Quick start: 新規リポのブートストラップ
+
+新規 ozzy-labs リポを最初から立ち上げる際のエンドツーエンドの手順。各スクリプトは完了時に "Next steps" ヒントを出力するため、本セクションは主に**順序**を示すもの。各コマンドの詳細フラグは下の各セクションを参照。
+
+1. **GitHub リポを作成してローカルに clone する。**
+
+   ```bash
+   gh repo create ozzy-labs/<name> --public --description "..."
+   gh repo clone ozzy-labs/<name>
+   cd <name>
+   ```
+
+2. **ozzy-labs 共通の GitHub 設定を適用する** — マージルール（squash のみ）、ブランチ保護、セキュリティ、Conventional Commits ラベル。
+
+   ```bash
+   /path/to/commons/setup-repo.sh ozzy-labs/<name>
+   ```
+
+3. **共通設定を同期する** — lefthook / mise / editorconfig / workflows などを配布し、`.commons/sync.yaml` を seed（`skills_commit:` / `skills_adapters:` の opt-in 用空キーも含む）。
+
+   ```bash
+   /path/to/commons/sync.sh -y .
+   ```
+
+4. **テンプレートをブートストラップする** — `AGENTS.md` / `CLAUDE.md` をコピーし、`{{project_name}}` / `{{description}}` プレースホルダを置換、加えて GitHub API でリポ description / topics を一括反映。
+
+   ```bash
+   /path/to/commons/init-templates.sh \
+     --name <name> \
+     --description "..." \
+     --topics ai,cli,multi-agent,... \
+     .
+   ```
+
+5. **（任意）`@ozzylabs/skills` に opt-in する** — `.commons/sync.yaml` の `skills_commit:` `skills_adapters:` を埋める。SHA 取得方法は seed されているコメント内に記載済み。続いて `sync-skills.sh` をローカルにクローンした `ozzy-labs/skills` に対して実行する。
+
+6. **プロジェクト固有ファイルを追加** — `package.json`, `tsconfig.json`, `src/` 等。`AGENTS.md` / `CLAUDE.md` の tech stack やプロジェクト概要も埋める。
+
+7. **ブートストラップ PR を作成する。** ステップ 2 で設置した ruleset により `main` への直接 push はブロックされている:
+
+   ```bash
+   git checkout -b chore/bootstrap
+   git add . && git commit -m "chore: bootstrap repo"
+   git push -u origin chore/bootstrap
+   gh pr create --fill && gh pr merge --squash --delete-branch
+   ```
+
 ## 使い方
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -41,6 +41,53 @@ init-templates.sh    -> Bootstrap templates with placeholder substitution + repo
 
 Shared skills (`.agents/skills/`, `.claude/skills/`) are no longer distributed from this repo. They live in [`ozzy-labs/skills`](https://github.com/ozzy-labs/skills) and are pulled into consumer repos via the `@ozzylabs/skills` Renovate preset (see [ADR-0016](https://github.com/ozzy-labs/handbook/blob/main/adr/0016-create-skills-repo.md)).
 
+## Quick start: bootstrap a new repo
+
+End-to-end flow for a brand-new ozzy-labs repo. Each script ends with its own "Next steps" hint, so this list is mainly about the order. Detailed flags for each command live in the sections below.
+
+1. **Create the GitHub repo and clone it locally.**
+
+   ```bash
+   gh repo create ozzy-labs/<name> --public --description "..."
+   gh repo clone ozzy-labs/<name>
+   cd <name>
+   ```
+
+2. **Apply ozzy-labs GitHub settings** — merge rules (squash only), branch protection, security, Conventional Commits labels.
+
+   ```bash
+   /path/to/commons/setup-repo.sh ozzy-labs/<name>
+   ```
+
+3. **Sync shared config** — distributes lefthook, mise, editorconfig, workflows, etc., and seeds `.commons/sync.yaml` (including the `skills_commit:` / `skills_adapters:` opt-in stubs).
+
+   ```bash
+   /path/to/commons/sync.sh -y .
+   ```
+
+4. **Bootstrap templates** — copies `AGENTS.md` / `CLAUDE.md`, substitutes `{{project_name}}` / `{{description}}` placeholders, and applies the repo description + topics via the GitHub API in one shot.
+
+   ```bash
+   /path/to/commons/init-templates.sh \
+     --name <name> \
+     --description "..." \
+     --topics ai,cli,multi-agent,... \
+     .
+   ```
+
+5. **(Optional) Opt in to `@ozzylabs/skills`** — edit `.commons/sync.yaml`'s `skills_commit:` and `skills_adapters:`. The seeded comment in the file names the exact `gh` command for fetching the SHA. Then run `sync-skills.sh` against a local clone of `ozzy-labs/skills`.
+
+6. **Add project-specific files** (`package.json`, `tsconfig.json`, `src/`, etc.) and edit `AGENTS.md` / `CLAUDE.md` to fill in tech stack and project specifics.
+
+7. **Open the bootstrap PR.** Direct push to `main` is blocked by the ruleset installed in step 2:
+
+   ```bash
+   git checkout -b chore/bootstrap
+   git add . && git commit -m "chore: bootstrap repo"
+   git push -u origin chore/bootstrap
+   gh pr create --fill && gh pr merge --squash --delete-branch
+   ```
+
 ## Usage
 
 ```bash


### PR DESCRIPTION
## Summary

- README.md と README.ja.md に「Quick start: bootstrap a new repo」セクションを追加。`gh repo create` → `setup-repo.sh` → `sync.sh` → `init-templates.sh` → （任意）`sync-skills.sh` → bootstrap PR の順序を**単一の番号付きリスト**で示す。
- 詳細なフラグや挙動は既存の per-command セクション（Sync / Check / Skills sync / Repository setup / Bootstrap templates）に委ね、Quick start からは概要と参照のみ。重複なし。
- 配置は per-command セクションの**前**。読者が高レベルのフローを先に把握してから詳細にドリルダウンできる構成。
- 既存セクションは無変更。

Closes #128

## Why

`ozzy-labs/agentic-watch#1` Phase 0 で報告された通り、新規リポを bootstrap する際に複数 section / 複数スクリプトを行き来して順序を再構成する必要があった。一気通貫の walk-through を README に置くことで、新規 consumer がコピー&ペーストで進められるようになる。

## Test plan

- [x] `pnpm run lint:md` 通過（markdownlint）
- [x] `prettier --check` 通過（README.md / README.ja.md）
- [x] `pnpm run test` 通過（129 / 129、ドキュメント変更のため回帰なし）
- [x] レンダリングは GitHub 上でセクション構造とリストが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)