### PR TITLE
chore(workflows): disable sync-commons cron in dist (push-mode transition)

### DIFF
--- a/dist/.github/workflows/sync-commons.yaml
+++ b/dist/.github/workflows/sync-commons.yaml
@@ -1,12 +1,17 @@
 # begin: ozzy-labs/commons
 name: Sync commons
 
-# Automated sync of shared configuration from ozzy-labs/commons.
+# Manual sync of shared configuration from ozzy-labs/commons.
 #
-# Runs on a weekly schedule (configurable) and on manual dispatch. When
-# the upstream commons repo has changes that are not yet reflected
-# in this repo (per `.commons/sync.yaml`, minus `pinned` entries), the
-# workflow runs `sync.sh --yes` and opens a pull request with the
+# Runs on manual dispatch only. The legacy cron-based weekly schedule was
+# disabled as part of the push-mode transition (ozzy-labs/skills epic #80,
+# Step 1) to avoid dual-write races with `/sync-consumers`. Going forward,
+# updates are pushed from ozzy-labs/commons via `/sync-consumers`; this
+# workflow remains for ad-hoc fallback only (workflow_dispatch).
+#
+# When invoked, if the upstream commons repo has changes that are not yet
+# reflected in this repo (per `.commons/sync.yaml`, minus `pinned` entries),
+# the workflow runs `sync.sh --yes` and opens a pull request with the
 # resulting diff. The PR is never auto-merged; review it.
 #
 # Prerequisites in the consumer repo:
@@ -14,9 +19,6 @@ name: Sync commons
 #     commons/setup-repo.sh)
 #   - `.commons/sync.yaml` exists (created on first manual sync.sh run).
 on:
-  schedule:
-    # Every Monday 00:00 UTC
-    - cron: "0 0 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

[ozzy-labs/skills epic #80](https://github.com/ozzy-labs/skills/issues/80) Step 1 の準備として、consumer 配布用の \`dist/.github/workflows/sync-commons.yaml\` から weekly cron トリガーを除去。今後は \`workflow_dispatch\` のみで起動する。

## 経緯

epic #80 で push 型 \`/sync-consumers\` を導入。dual-write race を避けるため、consumer 側で週次 cron で動く既存 sync workflow を「workflow_dispatch only」に絞る必要がある。本 PR は commons 側 SSOT 修正で、次のステップ (各 consumer への sync 配信) で各 consumer の root workflow にも反映する。

## 変更内容

- \`dist/.github/workflows/sync-commons.yaml\` の \`on.schedule.cron\` を削除
- 残るトリガーは \`workflow_dispatch\` のみ
- コメントに transition の経緯と参照 (ozzy-labs/skills#80 Step 1) を追記

## 影響範囲

- commons 自身の \`.github/workflows/sync-commons.yaml\` は **pinned** (commons は自身も consumer の特殊構造、\`.commons/sync.yaml\` の \`pinned\` に登録済) のため本 PR の影響を受けない
- 各 consumer への反映は \`commons/scripts/sync-consumers.sh\` で別途配信する (epic Step 1 後半)

## Test plan

- [x] \`./sync.sh --check .\` で self-sync drift なし (root sync-commons.yaml は pinned で skip)
- [x] \`pnpm run lint:all\` クリーン

Refs: ozzy-labs/skills#80 ozzy-labs/skills#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)