### PR TITLE
docs(sync): .commons/sync.yaml seed comment を push 型に書き換え

### DIFF
--- a/sync.sh
+++ b/sync.sh
@@ -292,13 +292,18 @@ write_metadata() {
 
   local tmp_file="${METADATA_FILE}.tmp.$$"
   {
-    echo "# Auto-updated by commons sync.sh"
-    echo "# 'pinned' is user-editable — add or remove paths freely"
+    echo "# Updated by /sync-consumers (push mode). 'commit' / 'skills_commit'"
+    echo "# log the last applied SHA; updates are pushed from ozzy-labs/commons"
+    echo "# (and ozzy-labs/skills) via the /sync-consumers skill, see"
+    echo "# ozzy-labs/skills#80. 'pinned' is user-editable — add or remove paths"
+    echo "# freely. 'commit' / 'skills_commit' / 'synced_at' should not be hand-"
+    echo "# edited; they are rewritten by sync.sh / sync-skills.sh on each push."
     echo "commit: ${COMMIT_HASH}"
     echo "synced_at: ${SYNCED_AT}"
     echo ""
-    echo "# Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA"
-    echo "# to skills_commit. The skills repo's main HEAD SHA can be obtained via:"
+    echo "# Skills sync (opt-in). Add adapter ids to skills_adapters; skills_commit"
+    echo "# is bumped by /sync-consumers --source=skills. The skills repo's main"
+    echo "# HEAD SHA can be obtained via:"
     echo "#   gh api repos/ozzy-labs/skills/commits/main --jq .sha"
     if [[ -n "${existing_skills_commit:-}" ]]; then
       echo "skills_commit: ${existing_skills_commit}"


### PR DESCRIPTION
## Summary

[ozzy-labs/skills epic #80](https://github.com/ozzy-labs/skills/issues/80) Step 6 として、\`sync.sh\` が consumer の \`.commons/sync.yaml\` を seed するときの header comment を「Auto-updated by commons sync.sh」から「Updated by /sync-consumers (push mode)」に意味変更。\`commit\` / \`skills_commit\` は **last applied SHA の log** として扱う旨を明示。

Refs: ozzy-labs/skills#80 ozzy-labs/skills#86

## 主な変更

\`sync.sh\` の seed 部分 (L295-302) を更新:

**旧:**
\`\`\`
# Auto-updated by commons sync.sh
# 'pinned' is user-editable — add or remove paths freely
\`\`\`

**新:**
\`\`\`
# Updated by /sync-consumers (push mode). 'commit' / 'skills_commit'
# log the last applied SHA; updates are pushed from ozzy-labs/commons
# (and ozzy-labs/skills) via the /sync-consumers skill, see
# ozzy-labs/skills#80. 'pinned' is user-editable — add or remove paths
# freely. 'commit' / 'skills_commit' / 'synced_at' should not be hand-
# edited; they are rewritten by sync.sh / sync-skills.sh on each push.
\`\`\`

skills_commit セクションの comment も「Add adapter ids ... and a SHA」→「skills_commit is bumped by \`/sync-consumers --source=skills\`」と更新。

## 伝播

新 comment は consumer に次回 sync 配信時 (\`sync.sh -y\` 実行時) に伝播。本 PR 自体は SSOT (\`sync.sh\` script) のみ変更。各 consumer への伝播は \`/sync-consumers\` 経由か、自然な次回 sync 時に取り込まれる。

## Test plan

- [x] \`bats tests/sync.bats\` の fixture (3 箇所) は input として使われており出力比較ではないため影響なし
- [x] \`pnpm test\` 全 137 test pass
- [x] \`pnpm run lint:all\` クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)