### PR TITLE
chore(prettier): ignore synced skill files to keep skills SSOT intact

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,11 @@
 
 node_modules/
 pnpm-lock.yaml
+
+# Synced skill files (SSOT lives in ozzy-labs/skills/src/skills/). The skills
+# repo formats these via biome, which produces different line-wrapping than
+# commons' prettier config (e.g. compact pipes vs aligned pipes in markdown
+# tables). Ignoring them here keeps the SSOT format intact and avoids
+# repeated drift after each `/sync-consumers --source=skills` push.
+.agents/skills/
+.claude/skills/


### PR DESCRIPTION
## Summary

skills 側 (ozzy-labs/skills) は \`src/skills/{name}/SKILL.md\` を biome で format して \`dist/\` に build する。commons は dist を直接 sync で取り込むため、commons 側 prettier (default config) と skills 側 biome の format ルールが衝突して \`.agents/skills/\` と \`.claude/skills/\` 配下の SKILL.md / perspectives/*.md で diff が発生していた。

実例: skills audit (本セッション) で発見した「commons の prettier 修正が次回 sync で skills SSOT に上書きされる」問題。[PR #141](https://github.com/ozzy-labs/commons/pull/141) で 29 file を prettier で format したが、SSOT は skills 側のままで diff が再発する。

Refs: ozzy-labs/skills#80 ozzy-labs/skills#86

## 修正

\`.prettierignore\` に以下を追加し、synced skill files を prettier 対象外に:

\`\`\`
.agents/skills/
.claude/skills/
\`\`\`

これで commons の \`lint:format\` は skill files を skip し、skills SSOT の biome format がそのまま維持される。\`lint:md\` / \`yamllint\` / \`shellcheck\` などの他の lint は引き続き適用される (拡張子ごとに別レイヤー)。

## Test plan

- [x] \`pnpm run lint:all\` クリーン
- [x] \`./sync.sh --check .\` で self-sync drift なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)