### PR TITLE
fix(sync-consumers): commons の sync.sh / sync-skills.sh を正しい path で呼ぶ

### DIFF
--- a/scripts/sync-consumers.sh
+++ b/scripts/sync-consumers.sh
@@ -176,11 +176,12 @@ trap_err() {
 
 # dry-run の場合: 想定処理を JSON で返す
 if $DRY_RUN; then
+  PLAN_COMMONS_REPO="${COMMONS_REPO:-${HOME}/github/ozzy-labs/commons}"
   PLAN_SYNC_CMD=""
   if [[ "$SOURCE" == "skills" ]]; then
-    PLAN_SYNC_CMD="$SOURCE_REPO/sync-skills.sh -y $SOURCE_REPO/dist <consumer-clone>"
+    PLAN_SYNC_CMD="$PLAN_COMMONS_REPO/sync-skills.sh -y $SOURCE_REPO/dist <consumer-clone>"
   else
-    PLAN_SYNC_CMD="$SOURCE_REPO/sync.sh -y <consumer-clone>"
+    PLAN_SYNC_CMD="$PLAN_COMMONS_REPO/sync.sh -y <consumer-clone>"
   fi
   MAYBE_AUTO_MERGE=""
   if $AUTO_MERGE; then
@@ -240,12 +241,20 @@ fi
 rm -f "${SYNC_YAML}.bak"
 
 # 4. sync.sh / sync-skills.sh 実行
+#
+# sync-skills.sh / sync.sh は両方 commons repo に置かれている (commons/sync.sh /
+# commons/sync-skills.sh)。--source=skills の場合も呼び出すのは commons の
+# sync-skills.sh で、第 1 引数として skills の dist を指す。
+COMMONS_SCRIPT_REPO="${COMMONS_REPO:-${HOME}/github/ozzy-labs/commons}"
+if [[ ! -d "$COMMONS_SCRIPT_REPO/.git" ]]; then
+  trap_err "commons repo not found at $COMMONS_SCRIPT_REPO (set COMMONS_REPO env to override)"
+fi
 if [[ "$SOURCE" == "skills" ]]; then
-  if ! "$SOURCE_REPO/sync-skills.sh" -y "$SOURCE_REPO/dist" "$CONSUMER_DIR" >&2; then
+  if ! "$COMMONS_SCRIPT_REPO/sync-skills.sh" -y "$SOURCE_REPO/dist" "$CONSUMER_DIR" >&2; then
     trap_err "sync-skills.sh failed"
   fi
 else
-  if ! "$SOURCE_REPO/sync.sh" -y "$CONSUMER_DIR" >&2; then
+  if ! "$COMMONS_SCRIPT_REPO/sync.sh" -y "$CONSUMER_DIR" >&2; then
     trap_err "sync.sh failed"
   fi
 fi


### PR DESCRIPTION
## Summary

helper script (\`scripts/sync-consumers.sh\`) が \`sync.sh\` / \`sync-skills.sh\` を呼ぶときに \`\$SOURCE_REPO\` 配下を参照していたが、両 script は **常に commons repo にしかない**。\`--source=skills\` の場合に \`\$SOURCE_REPO/sync-skills.sh = skills/sync-skills.sh\` を呼ぼうとして「No such file or directory」で fail していた。

## 実例

本セッションで sync 試行時に 14 consumer 全部が failed:
\`\`\`
scripts/sync-consumers.sh: line 244:
/home/ozzy/github/ozzy-labs/skills/sync-skills.sh: No such file or directory
\`\`\`

## 修正

- \`COMMONS_REPO\` env var を導入 (default: \`\$HOME/github/ozzy-labs/commons\`)
- \`sync.sh\` / \`sync-skills.sh\` の呼び出し path を \`\$COMMONS_REPO/\` に変更
- dry-run の \`would_run\` 表示も同様に修正
- \`COMMONS_REPO\` が git repo でなければ早期 error

## Test plan

- [x] 全 17 bats test pass
- [x] shellcheck / lint clean
- [x] \`./sync.sh --check .\` で self-sync drift なし

Refs: ozzy-labs/skills#80 ozzy-labs/skills#86

🤖 Generated with [Claude Code](https://claude.com/claude-code)