### PR TITLE
chore(scripts): migrate-consumer.sh で internal skill も削除対象に追加

### DIFF
--- a/scripts/migrate-consumer.sh
+++ b/scripts/migrate-consumer.sh
@@ -99,6 +99,15 @@ GENERIC_SKILLS=(
   lint-rules
 )
 
+# Internal-use skills (health/topics/phase-issue) も過去 sync の残骸として
+# 14 consumer に配布されたが、ADR-0027 で skills/commons 内部運用のみと決定。
+# migrate 経由で同時に清掃する。
+INTERNAL_SKILLS=(
+  health
+  topics
+  phase-issue
+)
+
 BRANCH="chore/migrate-to-user-skills"
 
 emit_json() {
@@ -149,7 +158,7 @@ REMOVED_SKILLS=()
 REMOVED_YAML_FIELDS=()
 ANY_CHANGE=false
 
-for skill in "${GENERIC_SKILLS[@]}"; do
+for skill in "${GENERIC_SKILLS[@]}" "${INTERNAL_SKILLS[@]}"; do
   if [[ -d ".claude/skills/$skill" ]]; then
     REMOVED_SKILLS+=("$skill")
     if ! $DRY_RUN; then


### PR DESCRIPTION
ADR-0027 で internal-use skill (health/topics/phase-issue) は skills/commons 内部運用のみと決定したが、過去 Renovate sync の残骸として 14 consumer にこれらの skill が配信されていた。GENERIC_SKILLS とは別の INTERNAL_SKILLS 配列を追加し、migrate ループで両方を清掃するようにする。

## 背景

- epic #96 audit 漏れ
- 14 consumer 全てで `.agents/skills/{health,topics,phase-issue}` および `.claude/skills/{health,topics,phase-issue}` が残存
- tech-notes main CI 連続失敗 7 件の根本原因 (prettier check fail on residue SKILL.md)

## 修正

- `GENERIC_SKILLS` (10 件) はそのまま、新規 `INTERNAL_SKILLS` 配列 (3 件)
- 削除ループは両方の配列を結合してイテレート

Refs: ozzy-labs/skills#96, ozzy-labs/handbook ADR-0027

🤖 Generated with [Claude Code](https://claude.com/claude-code)