### PR TITLE
fix: gate pre-commit trivy on HIGH/CRITICAL severity

### DIFF
--- a/dist/lefthook-base.yaml
+++ b/dist/lefthook-base.yaml
@@ -60,4 +60,7 @@ pre-commit:
     gitleaks:
       run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+      # Pre-commit gate: fail only on HIGH/CRITICAL vulnerabilities. A pre-existing
+      # LOW/MEDIUM/UNKNOWN (or fix-unavailable) advisory in a dependency must not
+      # block every unrelated commit; those are surfaced by CI / Dependabot instead.
+      run: mise exec -- trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --no-progress .

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -60,4 +60,7 @@ pre-commit:
     gitleaks:
       run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+      # Pre-commit gate: fail only on HIGH/CRITICAL vulnerabilities. A pre-existing
+      # LOW/MEDIUM/UNKNOWN (or fix-unavailable) advisory in a dependency must not
+      # block every unrelated commit; those are surfaced by CI / Dependabot instead.
+      run: mise exec -- trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --no-progress .


### PR DESCRIPTION
## 問題

配布する `lefthook-base.yaml` の pre-commit trivy hook が `--severity` 未指定:

```
trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
```

これは **LOW / MEDIUM / UNKNOWN や修正版のない advisory を含む、あらゆる依存脆弱性で全 commit をブロック**する。実際に複数の consumer repo（feedradar / gh-tasks / ozzylabs.com / starlight-theme 等）で、既存の依存 CVE のせいで**無関係な変更すら commit 不能**になっていた。

## 変更

pre-commit ゲートを **HIGH / CRITICAL のみで fail** させる:

```
trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --no-progress .
```

低 severity・修正不能な advisory は CI / Dependabot 側で扱う。root と `dist/`（配布物）双方の `lefthook-base.yaml` を更新。

## consumer への反映

各 consumer は commons sync（`sync.sh`）でこの hook を受け取る。同期後、pre-commit が HIGH/CRITICAL のみブロックになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)